### PR TITLE
Perform safe comparisons on double values

### DIFF
--- a/TFSAggregator/Aggregator.cs
+++ b/TFSAggregator/Aggregator.cs
@@ -9,6 +9,8 @@ using TFSAggregator;
 
 namespace TFSAggregator
 {
+    using TfsAggregator;
+
     public static class Aggregator
     {
         /// <summary>
@@ -46,7 +48,7 @@ namespace TFSAggregator
         {
             double aggregateValue = 0;
             // Iterate through all of the work items that we are pulling data from.
-            // For link typ of "Self" this will be just one item.  For "Parent" this will be all of the co-children of the work item sent in the event.
+            // For link type of "Self" this will be just one item.  For "Parent" this will be all of the co-children of the work item sent in the event.
             foreach (var sourceWorkItem in sourceWorkItems)
             {
                 // Iterate through all of the TFS Fields that we are aggregating.
@@ -57,7 +59,8 @@ namespace TFSAggregator
                 }
             }
 
-            if (aggregateValue != targetWorkItem.GetField<double>(configAggregatorItem.TargetField.Name, 0))
+            double currentValue = targetWorkItem.GetField<double>(configAggregatorItem.TargetField.Name, 0);
+            if (!aggregateValue.SafeEquals(currentValue))
             {
                 targetWorkItem[configAggregatorItem.TargetField.Name] = aggregateValue;
                 return targetWorkItem;

--- a/TFSAggregator/ComparisionOperator.cs
+++ b/TFSAggregator/ComparisionOperator.cs
@@ -3,6 +3,8 @@ using Microsoft.TeamFoundation.WorkItemTracking.Client;
 
 namespace TFSAggregator
 {
+    using TfsAggregator;
+
     public enum ComparisionOperator
     {
         LessThan,
@@ -26,6 +28,27 @@ namespace TFSAggregator
                     return leftSide != rightSide;
                 default:
                     return leftSide == rightSide;
+            }
+        }
+
+        public static bool Compare(this ComparisionOperator oper, double leftSide, double rightSide)
+        {
+            switch (oper)
+            {
+                case ComparisionOperator.LessThan:
+                    return leftSide.SafeCompareTo(rightSide) < 0;
+                case ComparisionOperator.GreaterThan:
+                    return leftSide.SafeCompareTo(rightSide) > 0;
+                case ComparisionOperator.LessThanOrEqualTo:
+                    return leftSide.SafeCompareTo(rightSide) <= 0;
+                case ComparisionOperator.GreaterThanOrEqualTo:
+                    return leftSide.SafeCompareTo(rightSide) >= 0;
+                case ComparisionOperator.EqualTo:
+                    return leftSide.SafeEquals(rightSide);
+                case ComparisionOperator.NotEqualTo:
+                    return !leftSide.SafeEquals(rightSide);
+                default:
+                    throw new ArgumentOutOfRangeException("oper");
             }
         }
 

--- a/TFSAggregator/Condition.cs
+++ b/TFSAggregator/Condition.cs
@@ -70,14 +70,10 @@ namespace TFSAggregator
                 }
                 if (leftType == typeof(double))
                 {
-                    //double leftValue, rightValue;
-                    //GetValues(workItem, out leftValue, out rightValue);
                     return CompOperator.Compare((double)leftSideValue, (double)rightSideValue);
                 }
                 if (leftType == typeof(DateTime))
                 {
-                    //DateTime leftValue, rightValue;
-                    //GetValues(workItem, out leftValue, out rightValue);
                     return CompOperator.Compare((DateTime)leftSideValue, (DateTime)rightSideValue);
                 }
 

--- a/TFSAggregator/DoubleExtensions.cs
+++ b/TFSAggregator/DoubleExtensions.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TfsAggregator
+{
+    public static class DoubleExtensions
+    {
+        public const double TfsEpsylon = 1e-15d;
+
+
+
+        public static bool SafeEquals(this double a, double b)
+        {
+            return SafeEquals(a, b, TfsEpsylon);
+        }
+
+        public static bool SafeEquals(this double a, double b, double epsilon)
+        {
+            double absA = Math.Abs(a);
+            double absB = Math.Abs(b);
+            double diff = Math.Abs(a - b);
+
+            if (a == b)
+            { // shortcut, handles infinities
+                return true;
+            }
+            else if (a == 0 || b == 0 || diff < Double.MinValue)
+            {
+                // a or b is zero or both are extremely close to it
+                // relative error is less meaningful here
+                return diff < (epsilon * Double.MinValue);
+            }
+            else
+            { // use relative error
+                return diff / (absA + absB) < epsilon;
+            }
+        }
+
+        public static int SafeCompareTo(this double a, double b)
+        {
+            return SafeCompareTo(a, b, TfsEpsylon);
+        }
+
+        public static int SafeCompareTo(this double a, double b, double epsilon)
+        {
+            if (SafeEquals(a, b))
+            {
+                return 0;
+            }
+            else
+            {
+                return a.CompareTo(b);
+            }
+        }
+    }
+}

--- a/TFSAggregator/Operations.cs
+++ b/TFSAggregator/Operations.cs
@@ -3,6 +3,8 @@ using TFSAggregator.ConfigTypes;
 
 namespace TFSAggregator
 {
+    using TfsAggregator;
+
     public static class Operations
     {
     
@@ -14,7 +16,7 @@ namespace TFSAggregator
                 return aggregateValue - sourceValue;
             if (operation == OperationEnum.Multiply)
             {
-                if  (aggregateValue == 0.0D)
+                if (aggregateValue.SafeEquals(0.0d))
                 {
                     aggregateValue = +1;
                 }
@@ -22,7 +24,7 @@ namespace TFSAggregator
             }
             if (operation == OperationEnum.Divide)
             {
-                if (aggregateValue == 0.0D)
+                if (aggregateValue.SafeEquals(0.0d))
                 {
                     aggregateValue = +1;
                     return (sourceValue / aggregateValue);

--- a/TFSAggregator/TFSAggregator.csproj
+++ b/TFSAggregator/TFSAggregator.csproj
@@ -40,31 +40,34 @@
   <ItemGroup>
     <Reference Include="Microsoft.TeamFoundation.Client, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Program Files (x86)\Microsoft Visual Studio 12.0\Common7\IDE\ReferenceAssemblies\v2.0\Microsoft.TeamFoundation.Client.dll</HintPath>
+      <HintPath>$(ProgramFiles%28x86%29)\Microsoft Visual Studio 12.0\Common7\IDE\ReferenceAssemblies\v2.0\Microsoft.TeamFoundation.Client.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.TeamFoundation.Common, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Program Files (x86)\Microsoft Visual Studio 12.0\Common7\IDE\ReferenceAssemblies\v2.0\Microsoft.TeamFoundation.Common.dll</HintPath>
+      <HintPath>$(ProgramFiles(x86))\Microsoft Visual Studio 12.0\Common7\IDE\ReferenceAssemblies\v2.0\Microsoft.TeamFoundation.Common.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.TeamFoundation.Framework.Server">
-      <HintPath>..\..\..\Program Files\Microsoft Team Foundation Server 12.0\Application Tier\Web Services\bin\Microsoft.TeamFoundation.Framework.Server.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\Program Files\Microsoft Team Foundation Server 12.0\Application Tier\Web Services\bin\Microsoft.TeamFoundation.Framework.Server.dll</HintPath>
       <Private>False</Private>
+    </Reference>
+    <Reference Include="Microsoft.TeamFoundation.Server.Core">
+      <HintPath>..\..\..\..\..\..\Program Files\Microsoft Team Foundation Server 12.0\Application Tier\Web Services\bin\Microsoft.TeamFoundation.Server.Core.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.TeamFoundation.WorkItemTracking.Client, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Program Files (x86)\Microsoft Visual Studio 12.0\Common7\IDE\ReferenceAssemblies\v2.0\Microsoft.TeamFoundation.WorkItemTracking.Client.dll</HintPath>
+      <HintPath>$(ProgramFiles(x86))\Microsoft Visual Studio 12.0\Common7\IDE\ReferenceAssemblies\v2.0\Microsoft.TeamFoundation.WorkItemTracking.Client.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.TeamFoundation.WorkItemTracking.Server">
-      <HintPath>..\..\..\Program Files\Microsoft Team Foundation Server 12.0\Application Tier\Web Services\bin\Microsoft.TeamFoundation.WorkItemTracking.Server.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\Program Files\Microsoft Team Foundation Server 12.0\Application Tier\Web Services\bin\Microsoft.TeamFoundation.WorkItemTracking.Server.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.TeamFoundation.WorkItemTracking.Server.Dataaccesslayer">
-      <HintPath>..\..\..\Program Files\Microsoft Team Foundation Server 12.0\Application Tier\Web Services\bin\Microsoft.TeamFoundation.WorkItemTracking.Server.Dataaccesslayer.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\Program Files\Microsoft Team Foundation Server 12.0\Application Tier\Web Services\bin\Microsoft.TeamFoundation.WorkItemTracking.Server.Dataaccesslayer.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Services.Common, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\Program Files (x86)\Microsoft Visual Studio 12.0\Common7\IDE\ReferenceAssemblies\v4.5\Microsoft.VisualStudio.Services.Common.dll</HintPath>
+      <HintPath>$(ProgramFiles(x86))\Microsoft Visual Studio 12.0\Common7\IDE\ReferenceAssemblies\v4.5\Microsoft.VisualStudio.Services.Common.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Services.WebApi, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="System" />
@@ -83,6 +86,7 @@
     <Compile Include="ConfigTypes\ConfigItemType.cs" />
     <Compile Include="ConfigTypes\ConfigLinkType.cs" />
     <Compile Include="ConfigTypes\Mapping.cs" />
+    <Compile Include="DoubleExtensions.cs" />
     <Compile Include="TfsFacade\FieldCollectionWrapper.cs" />
     <Compile Include="TfsFacade\FieldWrapper.cs" />
     <Compile Include="TfsFacade\IWorkItem.cs" />
@@ -111,6 +115,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <SubType>Designer</SubType>
     </Content>
+  </ItemGroup>
+  <ItemGroup>
+    <WCFMetadata Include="Service References\" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/UnitTests/SingleParentChildAggreagations.cs
+++ b/UnitTests/SingleParentChildAggreagations.cs
@@ -2,7 +2,6 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using TFSAggregator;
 using TFSAggregator.TfsFacade;
-using Microsoft.TeamFoundation.Framework.Server;
 using NSubstitute;
 using TFSAggregator.TfsSpecific;
 using System.Linq;
@@ -10,6 +9,8 @@ using TFS = Microsoft.TeamFoundation.WorkItemTracking.Client;
 
 namespace UnitTests
 {
+    using Microsoft.TeamFoundation.Framework.Server;
+
     [TestClass]
     public class SingleParentChildAggregations
     {

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -37,7 +37,7 @@
   <ItemGroup>
     <Reference Include="Microsoft.TeamFoundation.Common, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="Microsoft.TeamFoundation.Framework.Server">
-      <HintPath>..\..\..\Program Files\Microsoft Team Foundation Server 12.0\Application Tier\Web Services\bin\Microsoft.TeamFoundation.Framework.Server.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\Program Files\Microsoft Team Foundation Server 12.0\Application Tier\Web Services\bin\Microsoft.TeamFoundation.Framework.Server.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.TeamFoundation.WorkItemTracking.Client, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
     <Reference Include="NSubstitute">


### PR DESCRIPTION
There were a number of places in the code where double values were directly compared using the '==' and '!=' operators. These can result in false nagatives after a value has been round-tripped to the server (20/35 for example).

By using a slightly less precise Double.Epsylon the problem is resolved.

Closes: https://github.com/rbanks54/TFSAggregator/issues/3
