### PR TITLE
Refactor configuration with runtime section

### DIFF
--- a/Aggregator.Core/Configuration/AggregatorConfiguration.xsd
+++ b/Aggregator.Core/Configuration/AggregatorConfiguration.xsd
@@ -3,6 +3,53 @@
     <xs:element name="AggregatorConfiguration">
         <xs:complexType>
             <xs:sequence>
+                <xs:element minOccurs="0" maxOccurs="1" name="runtime">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element minOccurs="0" maxOccurs="1" name="logging">
+                                <xs:complexType>
+                                    <xs:attribute name="level" use="optional" default="Normal" >
+                                        <xs:simpleType>
+                                            <xs:restriction base="xs:string">
+                                                <xs:enumeration value="Critical"/>
+                                                <xs:enumeration value="Error"/>
+                                                <xs:enumeration value="Warning"/>
+                                                <xs:enumeration value="Information"/>
+                                                <xs:enumeration value="Normal"/>
+                                                <xs:enumeration value="Verbose"/>
+                                                <xs:enumeration value="Diagnostic"/>
+                                            </xs:restriction>
+                                        </xs:simpleType>
+                                    </xs:attribute>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element minOccurs="0" maxOccurs="1" name="script">
+                                <xs:complexType>
+                                    <xs:attribute name="language" use="optional" default="C#">
+                                        <xs:simpleType>
+                                            <xs:restriction base="xs:string">
+                                                <xs:enumeration value="CS"/>
+                                                <xs:enumeration value="CSharp"/>
+                                                <xs:enumeration value="C#"/>
+                                                <xs:enumeration value="VB"/>
+                                                <xs:enumeration value="VB.NET"/>
+                                                <xs:enumeration value="VBNET"/>
+                                                <xs:enumeration value="PS"/>
+                                                <xs:enumeration value="Powershell"/>
+                                                <xs:enumeration value="PowerShell"/>
+                                            </xs:restriction>
+                                        </xs:simpleType>
+                                    </xs:attribute>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element minOccurs="0" maxOccurs="1" name="authentication">
+                                <xs:complexType>
+                                    <xs:attribute name="autoImpersonate" type="xs:boolean" use="optional" default="false" />
+                                </xs:complexType>
+                            </xs:element>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
                 <xs:element minOccurs="1" maxOccurs="unbounded" name="rule">
                     <xs:complexType>
                         <xs:simpleContent>
@@ -53,21 +100,6 @@
                     </xs:unique>
                 </xs:element>
             </xs:sequence>
-            <xs:attribute name="logLevel" use="optional" default="Normal" >
-                <xs:simpleType>
-                    <xs:restriction base="xs:string">
-                        <xs:enumeration value="Critical"/>
-                        <xs:enumeration value="Error"/>
-                        <xs:enumeration value="Warning"/>
-                        <xs:enumeration value="Information"/>
-                        <xs:enumeration value="Normal"/>
-                        <xs:enumeration value="Verbose"/>
-                        <xs:enumeration value="Diagnostic"/>
-                    </xs:restriction>
-                </xs:simpleType>
-            </xs:attribute>
-            <xs:attribute name="autoImpersonate" type="xs:boolean" use="optional" default="false" />
-            <xs:attribute name="scriptLanguage" type="xs:string" use="optional" default="C#" />
         </xs:complexType>
     </xs:element>
 </xs:schema>

--- a/UnitTests.Core/ConfigurationsForTests/NoOp.policies
+++ b/UnitTests.Core/ConfigurationsForTests/NoOp.policies
@@ -1,5 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<AggregatorConfiguration logLevel="Diagnostic">
+<AggregatorConfiguration>
+
+    <runtime>
+        <logging level="Diagnostic"/>
+    </runtime>
 
     <!-- Do nothing -->
     <rule name="Noop" appliesTo="Task">

--- a/UnitTests.Core/ConfigurationsForTests/Rollup.policies
+++ b/UnitTests.Core/ConfigurationsForTests/Rollup.policies
@@ -1,5 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<AggregatorConfiguration logLevel="Diagnostic">
+<AggregatorConfiguration>
+
+    <runtime>
+        <logging level="Diagnostic"/>
+    </runtime>
 
     <!-- Add the time from the task up to the parent (Bug or PBI) -->
     <rule name="Rollup"

--- a/UnitTests.Core/ConfigurationsForTests/SimpleRollup.policies
+++ b/UnitTests.Core/ConfigurationsForTests/SimpleRollup.policies
@@ -1,5 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<AggregatorConfiguration logLevel="Diagnostic">
+<AggregatorConfiguration>
+
+    <runtime>
+        <logging level="Diagnostic"/>
+    </runtime>
 
     <!-- Add the time from the task up to the parent (Bug or PBI) -->
     <rule name="Rollup"

--- a/UnitTests.Core/ConfigurationsForTests/SumFieldsOnSingleWorkItem-Short.policies
+++ b/UnitTests.Core/ConfigurationsForTests/SumFieldsOnSingleWorkItem-Short.policies
@@ -1,5 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<AggregatorConfiguration logLevel="Diagnostic">
+<AggregatorConfiguration>
+
+    <runtime>
+        <logging level="Diagnostic"/>
+    </runtime>
 
     <!-- Add up the estimated work on the task -->
     <rule name="CalcEstimated"

--- a/UnitTests.Core/ConfigurationsForTests/SumFieldsOnSingleWorkItem.policies
+++ b/UnitTests.Core/ConfigurationsForTests/SumFieldsOnSingleWorkItem.policies
@@ -1,5 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<AggregatorConfiguration logLevel="Diagnostic">
+<AggregatorConfiguration>
+
+    <runtime>
+        <logging level="Diagnostic"/>
+    </runtime>
 
     <!-- Add up the estimated work on the task -->
     <rule name="CalcEstimated"

--- a/UnitTests.Core/ConfigurationsForTests/SumFieldsOnSingleWorkItemVB.policies
+++ b/UnitTests.Core/ConfigurationsForTests/SumFieldsOnSingleWorkItemVB.policies
@@ -1,5 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<AggregatorConfiguration logLevel="Diagnostic" scriptLanguage="VB">
+<AggregatorConfiguration>
+
+    <runtime>
+        <logging level="Diagnostic"/>
+        <script language="VB" />
+    </runtime>
 
     <!-- Add up the estimated work on the task -->
     <rule name="CalcEstimated"

--- a/UnitTests.Core/ConfigurationsForTests/allInOne.policies
+++ b/UnitTests.Core/ConfigurationsForTests/allInOne.policies
@@ -1,6 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <AggregatorConfiguration>
     
+    <runtime>
+        <logging level="Verbose"/>
+        <script language="VB" />
+    </runtime>
+    
     <!-- Add up the estimated work on the task -->
     <rule name="CalcEstimated"
           appliesTo="Task">

--- a/UnitTests.Core/ConfigurationsForTests/syntax.xml
+++ b/UnitTests.Core/ConfigurationsForTests/syntax.xml
@@ -1,6 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<AggregatorConfiguration
-    logLevel="Diagnostic" autoImpersonate="true" scriptLanguage="C#">
+<AggregatorConfiguration>
+
+    <runtime>
+        <logging level="Diagnostic"/>
+        <script language="C#" />
+        <authentication autoImpersonate="true" />
+    </runtime>
 
     <rule name="Type1"
           appliesTo="Task"><![CDATA[]]></rule>

--- a/UnitTests.Core/Settings.cs
+++ b/UnitTests.Core/Settings.cs
@@ -35,15 +35,15 @@ namespace UnitTests.Core
         public void Log_error_for_configuration_invalid_loglevel()
         {
             var logger = Substitute.For<ILogEvents>();
-            string config = @"<AggregatorConfiguration logLevel='Diag'></AggregatorConfiguration>";
+            string config = @"<AggregatorConfiguration><runtime><logging level='Diag'/></runtime></AggregatorConfiguration>";
 
             var settings = TFSAggregatorSettings.LoadXml(config, logger);
 
             Assert.IsNull(settings);
             logger.Received().InvalidConfiguration(
                 XmlSeverityType.Error,
-                "The 'logLevel' attribute is invalid - The value 'Diag' is invalid according to its datatype 'String' - The Enumeration constraint failed.",
-                1, 26);
+                "The 'level' attribute is invalid - The value 'Diag' is invalid according to its datatype 'String' - The Enumeration constraint failed.",
+                1, 44);
         }
 
         [TestMethod]


### PR DESCRIPTION
Forward compatible to add more logging, script engine and security settings

Moving "environmental" settings to an element, no more as root-element attributes allows for expansion