### PR TITLE
Add logging support for DotNet Scripts (rules).

### DIFF
--- a/Aggregator.Core/Aggregator.Core.csproj
+++ b/Aggregator.Core/Aggregator.Core.csproj
@@ -240,6 +240,8 @@
     </Compile>
     <Compile Include="Facade\ProcessTemplateVersionWrapper.cs" />
     <Compile Include="Interfaces\IProcessTemplateVersionWrapper.cs" />
+    <Compile Include="Monitoring\IRuleLogger.cs" />
+    <Compile Include="Monitoring\RuleLogger.cs" />
     <Compile Include="WorkItemImplementationBase.cs" />
     <Compile Include="Configuration\Policy.cs" />
     <Compile Include="Configuration\Rule.cs" />

--- a/Aggregator.Core/Monitoring/ILogEvents.cs
+++ b/Aggregator.Core/Monitoring/ILogEvents.cs
@@ -36,6 +36,10 @@ namespace Aggregator.Core.Monitoring
     /// <remarks>The methods must *not* raise exceptions.</remarks>
     public interface ILogEvents : ILogger
     {
+        IRuleLogger ScriptLogger { get; set; }
+
+        void ScriptLog(string ruleName, string s);
+
         void ConfigurationLoaded(string policyFile);
 
         void StartingProcessing(IRequestContext context, INotification notification);

--- a/Aggregator.Core/Monitoring/IRuleLogger.cs
+++ b/Aggregator.Core/Monitoring/IRuleLogger.cs
@@ -1,0 +1,11 @@
+﻿namespace Aggregator.Core.Monitoring
+{
+    public interface IRuleLogger : ITextLogger
+    {
+        string RuleName { get; set; }
+
+        void Log(string s);
+
+        void Log(string format, params object[] args);
+    }
+}

--- a/Aggregator.Core/Monitoring/RuleLogger.cs
+++ b/Aggregator.Core/Monitoring/RuleLogger.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Aggregator.Core.Monitoring
+{
+    public class RuleLogger : IRuleLogger
+    {
+        private readonly ILogEvents logger;
+
+        public RuleLogger(ILogEvents logger)
+        {
+            this.logger = logger;
+        }
+
+        public string RuleName { get; set; }
+
+        // forward to implementation
+        public LogLevel MinimumLogLevel
+        {
+            get
+            {
+                return this.logger.MinimumLogLevel;
+            }
+
+            set
+            {
+                this.logger.MinimumLogLevel = value;
+            }
+        }
+
+        public void Log(string format, params object[] args)
+        {
+            var s = string.Format(format, args);
+            this.Log(s);
+        }
+
+        public void Log(string s)
+        {
+            this.logger.ScriptLog(this.RuleName, s);
+        }
+
+        public void Log(LogLevel level, string format, params object[] args)
+        {
+            this.Log(format, args);
+        }
+    }
+}

--- a/Aggregator.Core/Monitoring/TextLogComposer.cs
+++ b/Aggregator.Core/Monitoring/TextLogComposer.cs
@@ -18,9 +18,12 @@ namespace Aggregator.Core.Monitoring
         public TextLogComposer(ITextLogger logger)
         {
             this.logger = logger;
+            this.ScriptLogger = new RuleLogger(this);
         }
 
         public ITextLogger TextLogger => this.logger;
+
+        public IRuleLogger ScriptLogger { get; set; }
 
         // forward to implementation
         public LogLevel MinimumLogLevel
@@ -160,7 +163,7 @@ namespace Aggregator.Core.Monitoring
 
         public void UnreferencedRule(string ruleName)
         {
-            logger.Log(
+            this.logger.Log(
                 LogLevel.Warning,
                 "Rule '{0}' is never used",
                 ruleName);
@@ -168,7 +171,7 @@ namespace Aggregator.Core.Monitoring
 
         public void ConfigurationLoaded(string policyFile)
         {
-            logger.Log(
+            this.logger.Log(
                 LogLevel.Information,
                 "Configuration loaded successfully from '{0}'",
                 policyFile);
@@ -176,7 +179,7 @@ namespace Aggregator.Core.Monitoring
 
         public void StartingProcessing(IRequestContext context, INotification notification)
         {
-            logger.Log(
+            this.logger.Log(
                 LogLevel.Information,
                 "Starting processing on workitem #{0}",
                 notification.WorkItemId);
@@ -184,7 +187,7 @@ namespace Aggregator.Core.Monitoring
 
         public void ProcessingCompleted(ProcessingResult result)
         {
-            logger.Log(
+            this.logger.Log(
                 LogLevel.Information,
                 "Processing completed: {0}",
                 result.StatusMessage);
@@ -192,7 +195,7 @@ namespace Aggregator.Core.Monitoring
 
         public void ApplyingPolicy(string name)
         {
-            logger.Log(
+            this.logger.Log(
                 LogLevel.Verbose,
                 "Policy '{0}' applies",
                 name);
@@ -200,7 +203,7 @@ namespace Aggregator.Core.Monitoring
 
         public void ApplyingRule(string name)
         {
-            logger.Log(
+            this.logger.Log(
                 LogLevel.Verbose,
                 "Evaluating Rule '{0}'",
                 name);
@@ -208,7 +211,7 @@ namespace Aggregator.Core.Monitoring
 
         public void BuildingScriptEngine(string scriptLanguage)
         {
-            logger.Log(
+            this.logger.Log(
                 LogLevel.Verbose,
                 "Building Script Engine for {0}",
                 scriptLanguage);
@@ -216,7 +219,7 @@ namespace Aggregator.Core.Monitoring
 
         public void RunningRule(string name, IWorkItem workItem)
         {
-            logger.Log(
+            this.logger.Log(
                 LogLevel.Verbose,
                 "Applying Rule '{0}' on #{1}",
                 name,
@@ -225,7 +228,7 @@ namespace Aggregator.Core.Monitoring
 
         public void FailureLoadingScript(string scriptName)
         {
-            logger.Log(
+            this.logger.Log(
                 LogLevel.Error,
                 "Failure in parsing '{0}' script",
                 scriptName);
@@ -233,7 +236,7 @@ namespace Aggregator.Core.Monitoring
 
         public void AttemptingToMoveWorkItemToState(IWorkItem workItem, string orginalSourceState, string destState)
         {
-            logger.Log(
+            this.logger.Log(
                 LogLevel.Verbose,
                 "Attempting to move {0} [{1}] from '{2}' to state '{3}'",
                 workItem.Type.Name,
@@ -244,48 +247,54 @@ namespace Aggregator.Core.Monitoring
 
         public void WorkItemIsValidToSave(IWorkItem workItem)
         {
-            logger.Log(LogLevel.Verbose, "WorkItem {0} [{1}] is valid to save", workItem.Type.Name, workItem.Id);
+            this.logger.Log(LogLevel.Verbose, "WorkItem {0} [{1}] is valid to save", workItem.Type.Name, workItem.Id);
         }
 
         public void WorkItemIsInvalidInState(IWorkItem workItem, string destState)
         {
-            logger.Log(LogLevel.Warning, "WorkItem is invalid in '{0}' state. Invalid fields: {1}"
+            this.logger.Log(LogLevel.Warning, "WorkItem is invalid in '{0}' state. Invalid fields: {1}"
                 , destState, workItem.GetInvalidWorkItemFieldsList());
         }
 
         public void LoadingConfiguration(string settingsPath)
         {
-            logger.Log(LogLevel.Diagnostic, "Loading Configuration from '{0}' ", settingsPath);
+            this.logger.Log(LogLevel.Diagnostic, "Loading Configuration from '{0}' ", settingsPath);
         }
 
         public void ConfigurationChanged(string settingsPath, CacheEntryRemovedReason removedReason)
         {
-            logger.Log(LogLevel.Information, "Configuration file '{0}' changed {1}", settingsPath, removedReason);
+            this.logger.Log(LogLevel.Information, "Configuration file '{0}' changed {1}", settingsPath, removedReason);
         }
 
         public void UsingCachedConfiguration(string settingsPath)
         {
-            logger.Log(LogLevel.Diagnostic, "Using cached Configuration for '{0}' ", settingsPath);
+            this.logger.Log(LogLevel.Diagnostic, "Using cached Configuration for '{0}' ", settingsPath);
         }
 
         public void AddingWorkItemLink(int sourceId, WorkItemLinkTypeEnd destLinkType, int destId)
         {
-            logger.Log(LogLevel.Information, "Adding work item link '{1}' from #{0} to #{2}", sourceId, destLinkType, destId);
+            this.logger.Log(LogLevel.Information, "Adding work item link '{1}' from #{0} to #{2}", sourceId, destLinkType, destId);
         }
 
         public void WorkItemLinkAlreadyExists(int sourceId, WorkItemLinkTypeEnd destLinkType, int destId)
         {
-            logger.Log(LogLevel.Warning, "Work item link '{1}' from #{0} to #{2} already exists", sourceId, destLinkType, destId);
+            this.logger.Log(LogLevel.Warning, "Work item link '{1}' from #{0} to #{2} already exists", sourceId, destLinkType, destId);
         }
 
         public void AddingHyperlink(int id, string destination, string comment)
         {
-            logger.Log(LogLevel.Information, "Adding hyperlink '{1}' on work item #{0} (comment: '{2}')", id, destination, comment);
+            this.logger.Log(LogLevel.Information, "Adding hyperlink '{1}' on work item #{0} (comment: '{2}')", id, destination, comment);
         }
 
         public void HyperlinkAlreadyExists(int id, string destination, string comment)
         {
-            logger.Log(LogLevel.Information, "Hyperlink '{1}' on work item #{0} already exists", id, destination);
+            this.logger.Log(LogLevel.Information, "Hyperlink '{1}' on work item #{0} already exists", id, destination);
         }
+
+        public void ScriptLog(string ruleName, string message)
+        {
+            this.logger.Log(LogLevel.Diagnostic, "{0}: {1}", ruleName, message);
+        }
+
     }
 }

--- a/Aggregator.Core/Script/CSharpScriptEngine.cs
+++ b/Aggregator.Core/Script/CSharpScriptEngine.cs
@@ -25,10 +25,11 @@ namespace RESERVED
   using Aggregator.Core.Extensions;
   using Aggregator.Core.Interfaces;
   using Aggregator.Core.Navigation;
+  using Aggregator.Core.Monitoring;
 
   public class Script_" + scriptName + @" : Aggregator.Core.Script.IDotNetScript
   {
-    public object RunScript(Aggregator.Core.Interfaces.IWorkItemExposed self, Aggregator.Core.Interfaces.IWorkItemRepositoryExposed store)
+    public object RunScript(Aggregator.Core.Interfaces.IWorkItemExposed self, Aggregator.Core.Interfaces.IWorkItemRepositoryExposed store, Aggregator.Core.Monitoring.IRuleLogger logger)
     {
 " + script + @"
       return null;

--- a/Aggregator.Core/Script/DotNetScriptEngine.cs
+++ b/Aggregator.Core/Script/DotNetScriptEngine.cs
@@ -13,7 +13,7 @@ namespace Aggregator.Core.Script
 {
     public interface IDotNetScript
     {
-        object RunScript(IWorkItemExposed self, IWorkItemRepositoryExposed store);
+        object RunScript(IWorkItemExposed self, IWorkItemRepositoryExposed store, IRuleLogger scriptLogger);
     }
 
     /// <summary>
@@ -108,9 +108,10 @@ namespace Aggregator.Core.Script
             }
 
             System.Diagnostics.Debug.WriteLine("*** about to execute {0}", scriptName, null);
+            this.logger.ScriptLogger.RuleName = scriptName;
 
             // Lets run our script and display its results
-            object result = scriptObject.RunScript(self, this.store);
+            object result = scriptObject.RunScript(self, this.store, this.logger.ScriptLogger);
             this.logger.ResultsFromScriptRun(scriptName, result);
         }
 

--- a/Aggregator.Core/Script/VBNetScriptEngine.cs
+++ b/Aggregator.Core/Script/VBNetScriptEngine.cs
@@ -23,12 +23,13 @@ Imports Aggregator.Core
 Imports Aggregator.Core.Extensions
 Imports Aggregator.Core.Interfaces
 Imports Aggregator.Core.Navigation
+Imports Aggregator.Core.Monitoring
 
 Namespace RESERVED
   Public Class Script_" + scriptName + @"
     Implements Aggregator.Core.Script.IDotNetScript
   
-    Public Function RunScript(ByVal self As Aggregator.Core.Interfaces.IWorkItemExposed, ByVal store As Aggregator.Core.Interfaces.IWorkItemRepositoryExposed) As Object Implements Aggregator.Core.Script.IDotNetScript.RunScript
+    Public Function RunScript(ByVal self As Aggregator.Core.Interfaces.IWorkItemExposed, ByVal store As Aggregator.Core.Interfaces.IWorkItemRepositoryExposed, ByVal logger As  Aggregator.Core.Monitoring.IRuleLogger) As Object Implements Aggregator.Core.Script.IDotNetScript.RunScript
 " + script + @"
       Return Nothing
     End Function

--- a/UnitTests.Core/ScriptEngines.cs
+++ b/UnitTests.Core/ScriptEngines.cs
@@ -186,5 +186,38 @@ return $self.Fields[""z""].Value ";
             Assert.AreEqual(0, result.ExceptionProperties.Count());
             Assert.AreEqual(EventNotificationStatus.ActionPermitted, result.NotificationStatus);
         }
+
+        [TestMethod]
+        [TestCategory("CSharpScript")]
+        public void Can_run_a_CSharp_script_with_logging()
+        {
+            string script = @"
+logger.Log(""Test"");
+";
+            var repository = Substitute.For<IWorkItemRepository>();
+            var workItem = Substitute.For<IWorkItem>();
+            var logger = Substitute.For<ILogEvents>();
+            logger.ScriptLogger = Substitute.For<IRuleLogger>();
+            var engine = new CSharpScriptEngine(repository, logger);
+            engine.LoadAndRun("test", script, workItem);
+            logger.ScriptLogger.Received().Log("Test");
+        }
+
+        [TestMethod]
+        [TestCategory("VBNetScript")]
+        public void Can_run_a_VBNet_script_with_logging()
+        {
+            string script = @"
+logger.Log(""Test"")
+";
+            var repository = Substitute.For<IWorkItemRepository>();
+            var workItem = Substitute.For<IWorkItem>();
+            var logger = Substitute.For<ILogEvents>();
+            logger.ScriptLogger = Substitute.For<IRuleLogger>();
+            var engine = new VBNetScriptEngine(repository, logger);
+            engine.LoadAndRun("test", script, workItem);
+            logger.ScriptLogger.Received().Log("Test");
+        }
+
     }
 }


### PR DESCRIPTION
Add support for using a logger object in the scripting code to emit debug statement.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/tfsaggregator/tfsaggregator/50)
<!-- Reviewable:end -->
