### PR TITLE
Don't use the requestContext from the cache.

### DIFF
--- a/Aggregator.Core/Context/RuntimeContext.cs
+++ b/Aggregator.Core/Context/RuntimeContext.cs
@@ -46,6 +46,10 @@ namespace Aggregator.Core.Context
 
                 Cache.Set(CacheKey, runtime, itemPolicy);
             }
+            else
+            {
+                runtime.RequestContext = requestContext;
+            }
 
             return runtime.Clone() as RuntimeContext;
         }


### PR DESCRIPTION
When the RequestContext is used from the cache, the CollectionName is not available.  This causes a null reference exception when running CollectionScope.Matches.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/tfsaggregator/tfsaggregator/53)
<!-- Reviewable:end -->
