### PR TITLE
Take workitem from session if it has been opened before

### DIFF
--- a/Aggregator.Core/EventProcessor.cs
+++ b/Aggregator.Core/EventProcessor.cs
@@ -109,8 +109,22 @@ namespace Aggregator.Core
 
         private void SaveChangedWorkItems()
         {
+            // Save new work items to the target work items.
+            foreach (IWorkItem workItem in this.store.CreatedWorkItems.Where(w => w.IsDirty))
+            {
+                this.ValidateAndSaveWorkItem(workItem);
+            }
+
             // Save any changes to the target work items.
             foreach (IWorkItem workItem in this.store.LoadedWorkItems.Where(w => w.IsDirty))
+            {
+                this.ValidateAndSaveWorkItem(workItem);
+            }
+        }
+
+        private void ValidateAndSaveWorkItem(IWorkItem workItem)
+        {
+            if (workItem.IsDirty)
             {
                 bool isValid = workItem.IsValid();
                 this.logger.Saving(workItem, isValid);

--- a/Aggregator.Core/Interfaces/IWorkItemRepository.cs
+++ b/Aggregator.Core/Interfaces/IWorkItemRepository.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.ObjectModel;
+﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
 
 namespace Aggregator.Core.Interfaces
 {
@@ -18,5 +19,7 @@ namespace Aggregator.Core.Interfaces
     public interface IWorkItemRepository : IWorkItemRepositoryExposed
     {
         ReadOnlyCollection<IWorkItem> LoadedWorkItems { get; }
+
+        ReadOnlyCollection<IWorkItem> CreatedWorkItems { get; }
     }
 }

--- a/UnitTests.Core/ItemCreationTests.cs
+++ b/UnitTests.Core/ItemCreationTests.cs
@@ -114,7 +114,8 @@ namespace UnitTests.Core
                 var result = processor.ProcessEvent(context, notification);
 
                 Assert.AreEqual(0, result.ExceptionProperties.Count());
-                Assert.AreEqual(2, repository.LoadedWorkItems.Count);
+                Assert.AreEqual(1, repository.LoadedWorkItems.Count);
+                Assert.AreEqual(1, repository.CreatedWorkItems.Count);
                 Assert.IsTrue(parent.InternalWasSaveCalled);
                 Assert.IsTrue(parent.HasChildren());
             }

--- a/UnitTests.Core/Mock/WorkItemRepositoryMock.cs
+++ b/UnitTests.Core/Mock/WorkItemRepositoryMock.cs
@@ -15,7 +15,7 @@ namespace UnitTests.Core.Mock
 
         private readonly List<IWorkItem> loadedWorkItems = new List<IWorkItem>();
 
-        private int newWorkItemId = -1;
+        private readonly List<IWorkItem> createdWorkItems = new List<IWorkItem>();
 
         public ILogEvents Logger { get; set; }
 
@@ -37,17 +37,22 @@ namespace UnitTests.Core.Mock
         public IWorkItem MakeNewWorkItem(string projectName, string workItemTypeName)
         {
             var newWorkItem = new WorkItemMock(this);
-            newWorkItem.Id = this.newWorkItemId--;
+            newWorkItem.Id = 0;
             newWorkItem.TypeName = workItemTypeName;
 
             // don't forget to add to collection
-            this.loadedWorkItems.Add(newWorkItem);
+            this.createdWorkItems.Add(newWorkItem);
             return newWorkItem;
         }
 
         public ReadOnlyCollection<IWorkItem> LoadedWorkItems
         {
             get { return new ReadOnlyCollection<IWorkItem>(this.loadedWorkItems); }
+        }
+
+        public ReadOnlyCollection<IWorkItem> CreatedWorkItems
+        {
+            get { return new ReadOnlyCollection<IWorkItem>(this.createdWorkItems); }
         }
     }
 }

--- a/UnitTests.Core/ScriptEngines.cs
+++ b/UnitTests.Core/ScriptEngines.cs
@@ -178,6 +178,8 @@ return $self.Fields[""z""].Value ";
                 notification.WorkItemId.Returns(1);
                 repository.LoadedWorkItems.Returns(
                     new ReadOnlyCollection<IWorkItem>(new List<IWorkItem>() { workItem }));
+                repository.CreatedWorkItems.Returns(
+                    new ReadOnlyCollection<IWorkItem>(new List<IWorkItem>()));
 
                 var result = processor.ProcessEvent(context, notification);
 

--- a/UnitTests.Core/SingleParentChildAggregations.cs
+++ b/UnitTests.Core/SingleParentChildAggregations.cs
@@ -40,6 +40,7 @@ namespace UnitTests.Core
 
             this.repository.GetWorkItem(1).Returns(this.workItem);
             this.repository.LoadedWorkItems.Returns(new ReadOnlyCollection<IWorkItem>(new List<IWorkItem>() { this.workItem }));
+            this.repository.CreatedWorkItems.Returns(new ReadOnlyCollection<IWorkItem>(new List<IWorkItem>()));
 
             return this.repository;
         }
@@ -61,7 +62,7 @@ namespace UnitTests.Core
 
             this.repository.GetWorkItem(1).Returns(this.workItem);
             this.repository.LoadedWorkItems.Returns(new ReadOnlyCollection<IWorkItem>(new List<IWorkItem>() { this.workItem }));
-
+            this.repository.CreatedWorkItems.Returns(new ReadOnlyCollection<IWorkItem>(new List<IWorkItem>()));
             return this.repository;
         }
 


### PR DESCRIPTION
Closes issue #54.

Implements separation between new work items and loaded workitems in the same session.

Changes loaded work items into a Dictionary for faster access,

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/tfsaggregator/tfsaggregator/55)
<!-- Reviewable:end -->
