### PR TITLE
GetGlobalList to solve parameters in work items

### DIFF
--- a/Aggregator.Core/Facade/WorkItemRepository.cs
+++ b/Aggregator.Core/Facade/WorkItemRepository.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Xml;
 
 using Aggregator.Core.Interfaces;
 using Aggregator.Core.Monitoring;
@@ -92,6 +93,30 @@ namespace Aggregator.Core.Facade
             }
 
             return this.MakeNewWorkItem(workItemTypeName, inSameProjectAs[CoreFieldReferenceNames.TeamProject] as string);
+        }
+
+        public IEnumerable<string> GetGlobalList(string globalListName)
+        {
+            //TODO this.logger.ReadingGlobalList(this.workItemStore.TeamProjectCollection.Name, globalListName);
+
+            // get Global Lists from TFS collection
+            var sourceGL = this.workItemStore.ExportGlobalLists();
+            return ParseGlobalList(sourceGL, globalListName);
+        }
+
+        // HACK public to allow Unit Testing
+        public static IEnumerable<string> ParseGlobalList(XmlDocument sourceGL, string globalListName)
+        {
+            var ns = new XmlNamespaceManager(sourceGL.NameTable);
+            ns.AddNamespace("gl", "http://schemas.microsoft.com/VisualStudio/2005/workitemtracking/globallists");
+
+            string xpath = string.Format("/gl:GLOBALLISTS/GLOBALLIST[@name='{0}']/LISTITEM/@value", globalListName);
+            var nodes = sourceGL.SelectNodes(xpath, ns);
+
+            foreach (XmlAttribute node in nodes)
+            {
+                yield return node.Value;
+            }
         }
 
         public void Dispose()

--- a/Aggregator.Core/Interfaces/IWorkItem.cs
+++ b/Aggregator.Core/Interfaces/IWorkItem.cs
@@ -46,6 +46,8 @@ namespace Aggregator.Core.Interfaces
 
         // state helpers; must be on interface to work on WorkItemLazyReference
         void TransitionToState(string state, string comment);
+
+        void Save();
     }
 
     public interface IWorkItemImplementation
@@ -62,8 +64,6 @@ namespace Aggregator.Core.Interfaces
         bool IsDirty { get; }
 
         void PartialOpen();
-
-        void Save();
 
         void TryOpen();
 

--- a/Aggregator.Core/Interfaces/IWorkItemRepository.cs
+++ b/Aggregator.Core/Interfaces/IWorkItemRepository.cs
@@ -13,6 +13,8 @@ namespace Aggregator.Core.Interfaces
         IWorkItem MakeNewWorkItem(string projectName, string workItemTypeName);
 
         IWorkItem MakeNewWorkItem(IWorkItem inSameProjectAs, string workItemTypeName);
+
+        IEnumerable<string> GetGlobalList(string globalListName);
     }
 
     /// <summary>

--- a/UnitTests.Core/ConfigurationsForTests/NewObjects.policies
+++ b/UnitTests.Core/ConfigurationsForTests/NewObjects.policies
@@ -23,6 +23,7 @@
         {
             var child = store.MakeNewWorkItem((string)parent["System.TeamProject"], "Task");
             child["Title"] = "Task auto-generated for " + parent["Title"];
+            child.Save();
             child.AddWorkItemLink(parent, WorkItemImplementationBase.ParentRelationship);
         }
         ]]>

--- a/UnitTests.Core/ConfigurationsForTests/UserParameters.policies
+++ b/UnitTests.Core/ConfigurationsForTests/UserParameters.policies
@@ -1,0 +1,36 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<AggregatorConfiguration>
+
+    <runtime>
+        <logging level="Diagnostic"/>
+    </runtime>
+
+    <!-- Smart replace -->
+    <rule name="UserParameters">
+        <![CDATA[
+        var paramGlobalList = store.GetGlobalList("Aggregator - UserParameters");
+        var userParams = paramGlobalList.ToDictionary(s => s.Split('=')[0], s => s.Split('=')[1]);
+        
+        string oldText = self["Title"].ToString();
+
+        string regex = @"\{(?<parName>\w+)\}(?:\([^\)]+\))?";
+        string newText = System.Text.RegularExpressions.Regex.Replace(
+              oldText,
+              regex,
+              (System.Text.RegularExpressions.Match m) =>
+              {
+                  string parName = m.Groups["parName"].Value;
+                  return string.Format("{{{0}}}({1})", parName, userParams[parName]);
+              },
+              System.Text.RegularExpressions.RegexOptions.Singleline);
+              
+        self["Title"] = newText;
+        ]]>
+    </rule>
+
+    <policy name="DefaultPolicy">
+        <collectionScope collections="*" />
+        <ruleRef name="UserParameters" />
+    </policy>
+
+</AggregatorConfiguration>

--- a/UnitTests.Core/ConfigurationsForTests/UserParameters.policies
+++ b/UnitTests.Core/ConfigurationsForTests/UserParameters.policies
@@ -13,14 +13,14 @@
         
         string oldText = self["Title"].ToString();
 
-        string regex = @"\{(?<parName>\w+)\}(?:\([^\)]+\))?";
+        string regex = @"\{(?<paramName>\w+)\}(?:\([^\)]+\))?";
         string newText = System.Text.RegularExpressions.Regex.Replace(
               oldText,
               regex,
               (System.Text.RegularExpressions.Match m) =>
               {
-                  string parName = m.Groups["parName"].Value;
-                  return string.Format("{{{0}}}({1})", parName, userParams[parName]);
+                  string paramName = m.Groups["paramName"].Value;
+                  return string.Format("{{{0}}}({1})", paramName, userParams[paramName]);
               },
               System.Text.RegularExpressions.RegexOptions.Singleline);
               

--- a/UnitTests.Core/GlobalListsTests.cs
+++ b/UnitTests.Core/GlobalListsTests.cs
@@ -1,0 +1,99 @@
+﻿using System.Linq;
+
+using Aggregator.Core;
+using Aggregator.Core.Context;
+using Aggregator.Core.Extensions;
+using Aggregator.Core.Interfaces;
+
+using Microsoft.TeamFoundation.Framework.Server;
+using Microsoft.TeamFoundation.WorkItemTracking.Client;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using NSubstitute;
+
+using UnitTests.Core.Mock;
+
+namespace UnitTests.Core
+{
+    [TestClass]
+    public class GlobalListsTests
+    {
+        [TestMethod]
+        public void GlobalList_get_Succeeded()
+        {
+            var repository = new WorkItemRepositoryMock();
+
+            var gl = repository.GetGlobalList("Aggregator - UserParameters").ToArray();
+
+            Assert.IsNotNull(gl);
+            Assert.AreEqual(1, gl.Length);
+            Assert.AreEqual("myParameter=30", gl[0]);
+        }
+
+        [TestMethod]
+        public void GlobalList_UserParameterAddValue_Succeeded()
+        {
+            var logger = new DebugEventLogger();
+            var settings = TestHelpers.LoadConfigFromResourceFile("UserParameters.policies", logger);
+
+            var repository = new WorkItemRepositoryMock();
+
+            var workItem = new WorkItemMock(repository);
+            workItem.Id = 1;
+            workItem.TypeName = "Use Case";
+            workItem["Title"] = "The car shall have a maximum speed of {myParameter} mph.";
+
+            repository.SetWorkItems(new[] { workItem });
+
+            var context = Substitute.For<IRequestContext>();
+            context.GetProjectCollectionUri().Returns(
+                new System.Uri("http://localhost:8080/tfs/DefaultCollection"));
+            var runtime = RuntimeContext.MakeRuntimeContext("settingsPath", settings, context, logger, (c, i, l) => repository);
+            using (var processor = new EventProcessor(runtime))
+            {
+                var notification = Substitute.For<INotification>();
+                notification.WorkItemId.Returns(1);
+
+                var result = processor.ProcessEvent(context, notification);
+
+                Assert.AreEqual(0, result.ExceptionProperties.Count());
+                Assert.IsTrue(workItem.InternalWasSaveCalled);
+                Assert.AreEqual("The car shall have a maximum speed of {myParameter}(30) mph.", workItem.Fields["Title"].Value);
+                Assert.AreEqual(EventNotificationStatus.ActionPermitted, result.NotificationStatus);
+            }
+        }
+
+        [TestMethod]
+        public void GlobalList_UserParameterReplaceExisting_Succeeded()
+        {
+            var logger = new DebugEventLogger();
+            var settings = TestHelpers.LoadConfigFromResourceFile("UserParameters.policies", logger);
+
+            var repository = new WorkItemRepositoryMock();
+
+            var workItem = new WorkItemMock(repository);
+            workItem.Id = 1;
+            workItem.TypeName = "Use Case";
+            workItem["Title"] = "The car shall have a maximum speed of {myParameter}(25) mph.";
+
+            repository.SetWorkItems(new[] { workItem });
+
+            var context = Substitute.For<IRequestContext>();
+            context.GetProjectCollectionUri().Returns(
+                new System.Uri("http://localhost:8080/tfs/DefaultCollection"));
+            var runtime = RuntimeContext.MakeRuntimeContext("settingsPath", settings, context, logger, (c, i, l) => repository);
+            using (var processor = new EventProcessor(runtime))
+            {
+                var notification = Substitute.For<INotification>();
+                notification.WorkItemId.Returns(1);
+
+                var result = processor.ProcessEvent(context, notification);
+
+                Assert.AreEqual(0, result.ExceptionProperties.Count());
+                Assert.IsTrue(workItem.InternalWasSaveCalled);
+                Assert.AreEqual("The car shall have a maximum speed of {myParameter}(30) mph.", workItem.Fields["Title"].Value);
+                Assert.AreEqual(EventNotificationStatus.ActionPermitted, result.NotificationStatus);
+            }
+        }
+    }
+}

--- a/UnitTests.Core/Mock/WorkItemMock.cs
+++ b/UnitTests.Core/Mock/WorkItemMock.cs
@@ -64,6 +64,7 @@ namespace UnitTests.Core.Mock
 
         public void Save()
         {
+            this.Id = ((WorkItemRepositoryMock)this.Store).PickNextId;
             this.internalSaveCalled++;
         }
 
@@ -143,6 +144,9 @@ namespace UnitTests.Core.Mock
 
         public void AddWorkItemLink(IWorkItemExposed destination, string linkTypeName)
         {
+            if (this.Id < 0 || destination.Id < 0)
+                throw new ApplicationException("emulate TF237128: Target workitem Id should be set before adding link to collection.");
+
             // HACK: should use the code in wrapper...
             var relationship = new WorkItemLinkMock(linkTypeName, destination.Id, this.Store);
 

--- a/UnitTests.Core/Mock/WorkItemRepositoryMock.cs
+++ b/UnitTests.Core/Mock/WorkItemRepositoryMock.cs
@@ -8,6 +8,7 @@ using Aggregator.Core.Interfaces;
 using Aggregator.Core.Monitoring;
 
 using Microsoft.TeamFoundation.WorkItemTracking.Client;
+using System.Xml;
 
 namespace UnitTests.Core.Mock
 {
@@ -56,6 +57,30 @@ namespace UnitTests.Core.Mock
             }
 
             return this.MakeNewWorkItem(workItemTypeName, inSameProjectAs[CoreFieldReferenceNames.TeamProject] as string);
+        }
+
+        public IEnumerable<string> GetGlobalList(string globalListName)
+        {
+            string boo = @"<gl:GLOBALLISTS xmlns:gl='http://schemas.microsoft.com/VisualStudio/2005/workitemtracking/globallists'>
+  <GLOBALLIST name='Builds - Share_Migration_toolkit_for_Sharepoint'>
+    <LISTITEM value='ShareMigrate2/ShareMigrate2_20130318.1' />
+  </GLOBALLIST>
+  <GLOBALLIST name='Builds - MyBuildTests'>
+    <LISTITEM value='DumpEnvironment/DumpEnvironment_20150528.1' />
+    <LISTITEM value='DumpEnvironment/DumpEnvironment_20150528.2' />
+    <LISTITEM value='DumpEnvironment/DumpEnvironment_20150528.3' />
+    <LISTITEM value='DumpEnvironment/DumpEnvironment_20150528.4' />
+    <LISTITEM value='DumpEnvironment/DumpEnvironment_20150528.5' />
+  </GLOBALLIST>
+  <GLOBALLIST name='Aggregator - UserParameters'>
+    <LISTITEM value= 'myParameter=30' />
+  </GLOBALLIST>
+</gl:GLOBALLISTS>";
+
+            var sourceGL = new XmlDocument();
+            sourceGL.LoadXml(boo);
+
+            return Aggregator.Core.Facade.WorkItemRepository.ParseGlobalList(sourceGL, globalListName);
         }
 
         public ReadOnlyCollection<IWorkItem> LoadedWorkItems

--- a/UnitTests.Core/Mock/WorkItemRepositoryMock.cs
+++ b/UnitTests.Core/Mock/WorkItemRepositoryMock.cs
@@ -2,13 +2,13 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Xml;
 
 using Aggregator.Core;
 using Aggregator.Core.Interfaces;
 using Aggregator.Core.Monitoring;
 
 using Microsoft.TeamFoundation.WorkItemTracking.Client;
-using System.Xml;
 
 namespace UnitTests.Core.Mock
 {
@@ -21,6 +21,11 @@ namespace UnitTests.Core.Mock
         private readonly List<IWorkItem> createdWorkItems = new List<IWorkItem>();
 
         public ILogEvents Logger { get; set; }
+
+        private int newItemId = 0;
+        private int nextValidId = 1000;
+
+        internal int PickNextId { get { return this.nextValidId++; } }
 
         public IWorkItem GetWorkItem(int workItemId)
         {
@@ -41,7 +46,7 @@ namespace UnitTests.Core.Mock
         {
             var newWorkItem = new WorkItemMock(this)
             {
-                Id = 0, TypeName = workItemTypeName
+                Id = --this.newItemId, TypeName = workItemTypeName
             };
 
             // don't forget to add to collection

--- a/UnitTests.Core/UnitTests.Core.csproj
+++ b/UnitTests.Core/UnitTests.Core.csproj
@@ -119,6 +119,7 @@
     <Compile Include="ContextCacheTests.cs" />
     <Compile Include="Helpers\DebugTextLogger.cs" />
     <Compile Include="Helpers\DebugEventLogger.cs" />
+    <Compile Include="GlobalListsTests.cs" />
     <Compile Include="RulesAndPolicyTests.cs" />
     <Compile Include="ItemCreationTests.cs" />
     <Compile Include="Mock\WorkItemLinkCollectionMock.cs" />
@@ -158,6 +159,9 @@
       <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="ConfigurationsForTests\RateLimiting.policies">
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
+    <EmbeddedResource Include="ConfigurationsForTests\UserParameters.policies">
       <SubType>Designer</SubType>
     </EmbeddedResource>
     <None Include="packages.config" />


### PR DESCRIPTION
A useful addition to read global lists.
May help in a scenario described here <http://stackoverflow.com/questions/33572697/using-parameters-in-description-of-tfs-work-item-types> (see GlobalList_UserParameter unit tests for ideas)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/tfsaggregator/tfsaggregator/88)
<!-- Reviewable:end -->
