### PR TITLE
fix #117 LastRevision returning current state

### DIFF
--- a/Aggregator.Core/Facade/WorkItemWrapper.cs
+++ b/Aggregator.Core/Facade/WorkItemWrapper.cs
@@ -171,9 +171,13 @@ namespace Aggregator.Core.Facade
         {
             get
             {
-                // works even on a new workitem with no revisions...
-                return new RevisionWrapper(
-                    this.workItem.Revisions[this.workItem.Revisions.Count - 1]);
+                // Revision starts at 1, so Revision-1 is last and Revision-2 is next-to-last
+                int lastRevisionNumber = this.workItem.Revision - 2;
+                if (lastRevisionNumber < 0)
+                {
+                    lastRevisionNumber = 0;
+                }
+                return new RevisionWrapper(this.workItem.Revisions[lastRevisionNumber]);
             }
         }
 


### PR DESCRIPTION
Tested with this rule

```
logger.Log("Revision {0} from {1}", self.Revision, self.LastRevision.Index);
const string fieldName = "System.Description";
var original = self.LastRevision.Fields[fieldName].Value;
var current = self.Fields[fieldName].Value;        
logger.Log("Value changed from '{0}' to '{1}'", original, current);
```

expected log trace is (edited for brevity)

```
TFSAggregator: [Verbose]     Applying Rule 'MyFirstRule' on #11
TFSAggregator.User: [Verbose]     MyFirstRule: Revision 1 from 0
TFSAggregator.User: [Verbose]     MyFirstRule: Value changed from 'initial desc' to 'initial desc'
TFSAggregator: [Information] Processing completed: Success

TFSAggregator: [Verbose]     Applying Rule 'MyFirstRule' on #11
TFSAggregator.User: [Verbose]     MyFirstRule: Revision 2 from 0
TFSAggregator.User: [Verbose]     MyFirstRule: Value changed from 'initial desc' to 'first desc change'
TFSAggregator: [Information] Processing completed: Success

TFSAggregator: [Verbose]     Applying Rule 'MyFirstRule' on #11
TFSAggregator.User: [Verbose]     MyFirstRule: Revision 3 from 1
TFSAggregator.User: [Verbose]     MyFirstRule: Value changed from 'first desc change' to 'second desc change'
TFSAggregator: [Information] Processing completed: Success
```

**Note** that a new Work Item has no previous history and the `LastRevision` property will return the current values instead.
In a rule, you can check this condition looking at `Revision` property: it values `1` for a new Work Item.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/tfsaggregator/tfsaggregator/118)
<!-- Reviewable:end -->
