### PR TITLE
NEW: configuration runtime/server/@baseUrl to force a host:port

### DIFF
--- a/Aggregator.ConsoleApp/RequestContext.cs
+++ b/Aggregator.ConsoleApp/RequestContext.cs
@@ -73,7 +73,7 @@ namespace Aggregator.ConsoleApp
             return projectProperties.Select(p => (IProjectProperty)new ProjectPropertyWrapper() { Name = p.Name, Value = p.Value }).ToArray();
         }
 
-        public IdentityDescriptor GetIdentityToImpersonate()
+        public IdentityDescriptor GetIdentityToImpersonate(Uri projectCollectionUrl)
         {
             // makes no sense impersonation in command line tool... for now
             return null;

--- a/Aggregator.Core/Aggregator.Core.csproj
+++ b/Aggregator.Core/Aggregator.Core.csproj
@@ -134,6 +134,7 @@
     <Compile Include="Extensions\BaseFieldValueValidator.cs" />
     <Compile Include="Extensions\DoubleFixFieldDecorator.cs" />
     <Compile Include="Extensions\FieldValueValidationDecorator.cs" />
+    <Compile Include="Extensions\UriExtensions.cs" />
     <Compile Include="Extensions\LocationServiceExtensions.cs" />
     <Compile Include="Extensions\IncorrectDataTypeFieldValidator.cs" />
     <Compile Include="Extensions\InvalidValueFieldValueValidator.cs" />

--- a/Aggregator.Core/Configuration/AggregatorConfiguration.xsd
+++ b/Aggregator.Core/Configuration/AggregatorConfiguration.xsd
@@ -53,6 +53,11 @@
                   <xs:attribute name="autoImpersonate" type="xs:boolean" use="optional" default="false" />
                 </xs:complexType>
               </xs:element>
+              <xs:element minOccurs="0" maxOccurs="1" name="server">
+                <xs:complexType>
+                  <xs:attribute name="baseUrl" type="xs:string" use="optional" />
+                </xs:complexType>
+              </xs:element>
             </xs:sequence>
             <xs:attribute name="debug" type="xs:boolean" use="optional" default="false" />
           </xs:complexType>

--- a/Aggregator.Core/Configuration/AggregatorSettingsXmlParser.cs
+++ b/Aggregator.Core/Configuration/AggregatorSettingsXmlParser.cs
@@ -85,6 +85,12 @@ namespace Aggregator.Core.Configuration
                 }
             }
 
+            /// <summary>
+            /// Simple hash to detect configuration changes
+            /// </summary>
+            /// <param name="doc">Configuration XML document.</param>
+            /// <param name="timestamp">Last time the document has been changed.</param>
+            /// <returns>Hexadecimal string represting hash value</returns>
             private string ComputeHash(XDocument doc, DateTime timestamp)
             {
                 using (var stream = new System.IO.MemoryStream())
@@ -153,6 +159,13 @@ namespace Aggregator.Core.Configuration
                     doc.Root.Element("runtime")?.Element("script") : null;
 
                 this.instance.ScriptLanguage = scriptNode?.Attribute("language").Value ?? "C#";
+
+                var serverNode = doc.Root.Element("runtime") != null ?
+                    doc.Root.Element("runtime")?.Element("server") : null;
+                string baseUrl = serverNode?.Attribute("baseUrl").Value;
+                this.instance.ServerBaseUrl = string.IsNullOrWhiteSpace(baseUrl)
+                    ? null
+                    : new Uri(new Uri(baseUrl).GetLeftPart(UriPartial.Authority));
             }
 
             private List<Policy> ParsePoliciesSection(XDocument doc, Dictionary<string, Rule> rules)

--- a/Aggregator.Core/Configuration/TFSAggregatorSettings.cs
+++ b/Aggregator.Core/Configuration/TFSAggregatorSettings.cs
@@ -52,6 +52,8 @@ namespace Aggregator.Core.Configuration
 
         public bool AutoImpersonate { get; private set; }
 
+        public Uri ServerBaseUrl { get; private set; }
+
         public string Hash { get; private set; }
 
         public IEnumerable<Rule> Rules { get; private set; }

--- a/Aggregator.Core/Context/RuntimeContext.cs
+++ b/Aggregator.Core/Context/RuntimeContext.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Runtime.Caching;
 
 using Aggregator.Core.Configuration;
+using Aggregator.Core.Extensions;
 using Aggregator.Core.Interfaces;
 using Aggregator.Core.Monitoring;
 
@@ -149,12 +150,13 @@ namespace Aggregator.Core.Context
 
         protected virtual IWorkItemRepository CreateWorkItemRepository()
         {
-            var uri = this.RequestContext.GetProjectCollectionUri();
+            var requestUri = this.RequestContext.GetProjectCollectionUri();
+            var uri = requestUri.ApplyServerSetting(this);
 
             Microsoft.TeamFoundation.Framework.Client.IdentityDescriptor toImpersonate = null;
             if (this.Settings.AutoImpersonate)
             {
-                toImpersonate = this.RequestContext.GetIdentityToImpersonate();
+                toImpersonate = this.RequestContext.GetIdentityToImpersonate(uri);
             }
 
             var newRepo = this.repoBuilder(uri, toImpersonate, this);

--- a/Aggregator.Core/Extensions/UriExtensions.cs
+++ b/Aggregator.Core/Extensions/UriExtensions.cs
@@ -1,0 +1,25 @@
+﻿using System;
+
+using Aggregator.Core.Context;
+
+namespace Aggregator.Core.Extensions
+{
+    public static class UriExtensions
+    {
+        public static Uri ApplyServerSetting(this Uri requestUri, RuntimeContext context)
+        {
+            if (context.Settings.ServerBaseUrl == null)
+            {
+                return requestUri;
+            }
+            else
+            {
+                var builder = new UriBuilder(context.Settings.ServerBaseUrl);
+                builder.Path = requestUri.AbsolutePath;
+                builder.Query = requestUri.Query;
+                var uri = builder.Uri;
+                return uri;
+            }
+        }
+    }
+}

--- a/Aggregator.Core/Facade/RequestContextWrapper.cs
+++ b/Aggregator.Core/Facade/RequestContextWrapper.cs
@@ -61,9 +61,7 @@ namespace Aggregator.Core.Facade
 
         public Uri GetProjectCollectionUri()
         {
-            ILocationService service = this.context.GetService<ILocationService>();
-
-            return service.GetSelfReferenceUri(this.context, service.GetDefaultAccessMapping(this.context));
+            return this.GetCollectionUriFromContext(this.context);
         }
 
         public IProjectProperty[] GetProjectProperties(Uri projectUri)
@@ -79,11 +77,9 @@ namespace Aggregator.Core.Facade
             return projectProperties.Select(p => (IProjectProperty)new ProjectPropertyWrapper() { Name = p.Name, Value = p.Value }).ToArray();
         }
 
-        public IdentityDescriptor GetIdentityToImpersonate()
+        public IdentityDescriptor GetIdentityToImpersonate(Uri projectCollectionUrl)
         {
-            Uri server = this.GetCollectionUriFromContext(this.context);
-
-            var configurationServer = TfsTeamProjectCollectionFactory.GetTeamProjectCollection(server);
+            var configurationServer = TfsTeamProjectCollectionFactory.GetTeamProjectCollection(projectCollectionUrl);
 
             // TODO: Find a way to read the identity from the server object model instead.
             IIdentityManagementService identityManagementService =

--- a/Aggregator.Core/Interfaces/IRequestContext.cs
+++ b/Aggregator.Core/Interfaces/IRequestContext.cs
@@ -15,7 +15,7 @@ namespace Aggregator.Core.Interfaces
 
         IProjectProperty[] GetProjectProperties(Uri teamProjectUri);
 
-        Microsoft.TeamFoundation.Framework.Client.IdentityDescriptor GetIdentityToImpersonate();
+        Microsoft.TeamFoundation.Framework.Client.IdentityDescriptor GetIdentityToImpersonate(Uri projectCollectionUrl);
 
         INotification Notification { get; }
     }

--- a/UnitTests.Core/SettingsTests.cs
+++ b/UnitTests.Core/SettingsTests.cs
@@ -192,5 +192,26 @@ namespace UnitTests.Core
 
             Assert.AreEqual(settings.RateLimit?.Interval, TimeSpan.FromHours(1));
         }
+
+        [TestMethod]
+        public void Policy_ServerBaseUrl_succeed()
+        {
+            var logger = Substitute.For<ILogEvents>();
+
+            string config = @"
+<AggregatorConfiguration>
+    <runtime>
+        <server baseUrl = ""http://tfs.example.local:8080/"" />
+    </runtime>
+    <rule name='dummy' />
+    <policy name='dummy' >
+        <ruleRef name='dummy' />
+    </policy>
+</AggregatorConfiguration>";
+
+            var settings = TFSAggregatorSettings.LoadXml(config, logger);
+
+            Assert.AreEqual(settings.ServerBaseUrl, new Uri("http://tfs.example.local:8080/"));
+        }
     }
 }


### PR DESCRIPTION
To help in #115 now it is possible to force the first part of the URL (protocol://host:port/) via configuration, e.g.

```
  <runtime>
    <server baseUrl="http://localhost:8080/" />
  </runtime>
```

The scope elements may ignore it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tfsaggregator/tfsaggregator/120)
<!-- Reviewable:end -->
