### PR TITLE
Feature: sharing code between rules

### DIFF
--- a/Aggregator.Core/Aggregator.Core.csproj
+++ b/Aggregator.Core/Aggregator.Core.csproj
@@ -124,10 +124,13 @@
       <Link>AssemblyVersion.cs</Link>
     </Compile>
     <Compile Include="Configuration\AggregatorSettingsXmlParser.cs" />
+    <Compile Include="Configuration\ScriptElement.cs" />
     <Compile Include="Configuration\CollectionScope.cs" />
     <Compile Include="Configuration\HasFieldsScope.cs" />
     <Compile Include="Configuration\ProjectScope.cs" />
     <Compile Include="Configuration\RateLimit.cs" />
+    <Compile Include="Configuration\Function.cs" />
+    <Compile Include="Configuration\Snippet.cs" />
     <Compile Include="Configuration\ScopeMatchResult.cs" />
     <Compile Include="Configuration\TemplateScope.cs" />
     <Compile Include="Configuration\WorkItemTypeScope.cs" />

--- a/Aggregator.Core/Aggregator.Core.csproj
+++ b/Aggregator.Core/Aggregator.Core.csproj
@@ -156,6 +156,7 @@
     <Compile Include="RateLimiter.cs" />
     <Compile Include="Script\DotNetScriptEngine{TCodeDomProvider}.cs" />
     <Compile Include="Script\IDotNetScript.cs" />
+    <Compile Include="Script\ScriptSourceElement.cs" />
     <Compile Include="WorkItemImplementationBase.cs" />
     <Compile Include="Configuration\Policy.cs" />
     <Compile Include="Configuration\Rule.cs" />

--- a/Aggregator.Core/Configuration/AggregatorConfiguration.xsd
+++ b/Aggregator.Core/Configuration/AggregatorConfiguration.xsd
@@ -62,6 +62,26 @@
             <xs:attribute name="debug" type="xs:boolean" use="optional" default="false" />
           </xs:complexType>
         </xs:element>
+        <xs:element minOccurs="0" maxOccurs="unbounded" name="snippet">
+          <xs:complexType>
+            <xs:simpleContent>
+              <xs:extension base="xs:string">
+                <xs:attribute name="name" type="xs:ID" use="required" />
+              </xs:extension>
+            </xs:simpleContent>
+          </xs:complexType>
+          <xs:unique name="uniqueSnippetName">
+            <xs:selector xpath="./snippet"/>
+            <xs:field xpath="name"/>
+          </xs:unique>
+        </xs:element>
+        <xs:element minOccurs="0" maxOccurs="unbounded" name="function">
+          <xs:complexType>
+            <xs:simpleContent>
+              <xs:extension base="xs:string"/>
+            </xs:simpleContent>
+          </xs:complexType>
+        </xs:element>
         <xs:element minOccurs="1" maxOccurs="unbounded" name="rule">
           <xs:complexType>
             <xs:simpleContent>

--- a/Aggregator.Core/Configuration/AggregatorSettingsXmlParser.cs
+++ b/Aggregator.Core/Configuration/AggregatorSettingsXmlParser.cs
@@ -49,6 +49,9 @@ namespace Aggregator.Core.Configuration
                 // XML Schema has done lot of checking and set defaults, no need to recheck later, just manage missing pieces
                 this.ParseRuntimeSection(doc);
 
+                this.instance.Snippets = this.ParseSnippetsSection(doc);
+                this.instance.Functions = this.ParseFunctionsSection(doc);
+
                 Dictionary<string, Rule> rules = this.ParseRulesSection(doc);
 
                 List<Policy> policies = this.ParsePoliciesSection(doc, rules);
@@ -247,6 +250,37 @@ namespace Aggregator.Core.Configuration
                 }
 
                 return policies;
+            }
+
+            private List<Snippet> ParseSnippetsSection(XDocument doc)
+            {
+                var snippets = new List<Snippet>();
+                foreach (var snippetElem in doc.Root.Elements("snippet"))
+                {
+                    var snippet = new Snippet()
+                    {
+                        Name = snippetElem.Attribute("name").Value,
+                        Script = snippetElem.Value
+                    };
+                    snippets.Add(snippet);
+                }
+
+                return snippets;
+            }
+
+            private IList<Function> ParseFunctionsSection(XDocument doc)
+            {
+                var functions = new List<Function>();
+                foreach (var functionElem in doc.Root.Elements("function"))
+                {
+                    var function = new Function();
+
+                    function.Script = functionElem.Value;
+
+                    functions.Add(function);
+                }
+
+                return functions;
             }
 
             private Dictionary<string, Rule> ParseRulesSection(XDocument doc)

--- a/Aggregator.Core/Configuration/Function.cs
+++ b/Aggregator.Core/Configuration/Function.cs
@@ -1,0 +1,9 @@
+﻿namespace Aggregator.Core.Configuration
+{
+    /// <summary>
+    /// Represents a Function of <see cref="TFSAggregatorSettings"/>.
+    /// </summary>
+    public class Function : ScriptElement
+    {
+    }
+}

--- a/Aggregator.Core/Configuration/Rule.cs
+++ b/Aggregator.Core/Configuration/Rule.cs
@@ -3,12 +3,10 @@
     /// <summary>
     /// Represents a Rule of <see cref="TFSAggregatorSettings"/>.
     /// </summary>
-    public class Rule
+    public class Rule : ScriptElement
     {
         public string Name { get; set; }
 
         public RuleScope[] Scope { get; set; }
-
-        public string Script { get; set; }
     }
 }

--- a/Aggregator.Core/Configuration/ScriptElement.cs
+++ b/Aggregator.Core/Configuration/ScriptElement.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Aggregator.Core.Configuration
+{
+    public abstract class ScriptElement
+    {
+        public string Script { get; set; }
+    }
+}

--- a/Aggregator.Core/Configuration/Snippet.cs
+++ b/Aggregator.Core/Configuration/Snippet.cs
@@ -1,0 +1,10 @@
+﻿namespace Aggregator.Core.Configuration
+{
+    /// <summary>
+    /// Represents a Snippet of <see cref="TFSAggregatorSettings"/>.
+    /// </summary>
+    public class Snippet : ScriptElement
+    {
+        public string Name { get; set; }
+    }
+}

--- a/Aggregator.Core/Configuration/TFSAggregatorSettings.cs
+++ b/Aggregator.Core/Configuration/TFSAggregatorSettings.cs
@@ -56,6 +56,10 @@ namespace Aggregator.Core.Configuration
 
         public string Hash { get; private set; }
 
+        public IEnumerable<Snippet> Snippets { get; private set; }
+
+        public IEnumerable<Function> Functions { get; private set; }
+
         public IEnumerable<Rule> Rules { get; private set; }
 
         public IEnumerable<Policy> Policies { get; private set; }

--- a/Aggregator.Core/Context/RuntimeContext.cs
+++ b/Aggregator.Core/Context/RuntimeContext.cs
@@ -134,12 +134,17 @@ namespace Aggregator.Core.Context
             {
                 System.Diagnostics.Debug.WriteLine("Cache empty for thread {0}", System.Threading.Thread.CurrentThread.ManagedThreadId);
                 this.cachedEngine = ScriptEngine.MakeEngine(this.Settings.ScriptLanguage, this.Logger, this.Settings.Debug);
-                foreach (var rule in this.Settings.Rules)
-                {
-                    this.cachedEngine.Load(rule.Name, rule.Script);
-                }
-
-                this.cachedEngine.LoadCompleted();
+                var sourceElements = this.Settings.Rules.ToList().ConvertAll(
+                    (rule) =>
+                    {
+                        return new Script.ScriptSourceElement()
+                        {
+                            Name = rule.Name,
+                            Type = Script.ScriptSourceElementType.Rule,
+                            SourceCode = rule.Script
+                        };
+                    });
+                this.cachedEngine.Load(sourceElements);
             }
 
             return this.cachedEngine;

--- a/Aggregator.Core/Context/RuntimeContext.cs
+++ b/Aggregator.Core/Context/RuntimeContext.cs
@@ -134,20 +134,52 @@ namespace Aggregator.Core.Context
             {
                 System.Diagnostics.Debug.WriteLine("Cache empty for thread {0}", System.Threading.Thread.CurrentThread.ManagedThreadId);
                 this.cachedEngine = ScriptEngine.MakeEngine(this.Settings.ScriptLanguage, this.Logger, this.Settings.Debug);
-                var sourceElements = this.Settings.Rules.ToList().ConvertAll(
-                    (rule) =>
-                    {
-                        return new Script.ScriptSourceElement()
-                        {
-                            Name = rule.Name,
-                            Type = Script.ScriptSourceElementType.Rule,
-                            SourceCode = rule.Script
-                        };
-                    });
+
+                List<Script.ScriptSourceElement> sourceElements = this.GetSourceElements();
+
                 this.cachedEngine.Load(sourceElements);
             }
 
             return this.cachedEngine;
+        }
+
+        private List<Script.ScriptSourceElement> GetSourceElements()
+        {
+            var sourceElements = new List<Script.ScriptSourceElement>();
+            var snippetElements = this.Settings.Snippets.ToList().ConvertAll(
+                (snippet) =>
+                {
+                    return new Script.ScriptSourceElement()
+                    {
+                        Name = snippet.Name,
+                        Type = Script.ScriptSourceElementType.Snippet,
+                        SourceCode = snippet.Script
+                    };
+                });
+            sourceElements.AddRange(snippetElements);
+            var ruleElements = this.Settings.Rules.ToList().ConvertAll(
+                (rule) =>
+                {
+                    return new Script.ScriptSourceElement()
+                    {
+                        Name = rule.Name,
+                        Type = Script.ScriptSourceElementType.Rule,
+                        SourceCode = rule.Script
+                    };
+                });
+            sourceElements.AddRange(ruleElements);
+            var functionElements = this.Settings.Functions.ToList().ConvertAll(
+                (function) =>
+                {
+                    return new Script.ScriptSourceElement()
+                    {
+                        Name = string.Empty,
+                        Type = Script.ScriptSourceElementType.Function,
+                        SourceCode = function.Script
+                    };
+                });
+            sourceElements.AddRange(functionElements);
+            return sourceElements;
         }
 
         // isolate type constructor to facilitate Unit testing

--- a/Aggregator.Core/Script/CSharpScriptEngine.cs
+++ b/Aggregator.Core/Script/CSharpScriptEngine.cs
@@ -23,7 +23,7 @@ namespace Aggregator.Core
             }
         }
 
-        protected override string WrapScript(string scriptName, string script)
+        protected override string WrapScript(string scriptName, string script, string functions)
         {
             return "namespace " + this.Namespace + @"
 {
@@ -43,6 +43,7 @@ namespace Aggregator.Core
 " + script + @"
       return null;
     }
+" + functions + @"
   }
 }
 ";

--- a/Aggregator.Core/Script/DotNetScriptEngine{TCodeDomProvider}.cs
+++ b/Aggregator.Core/Script/DotNetScriptEngine{TCodeDomProvider}.cs
@@ -173,7 +173,7 @@ namespace Aggregator.Core.Script
 
         private CompilerResults compilerResult;
 
-        public override bool Load(Script.ScriptSourceElement sourceElement)
+        internal override bool Load(Script.ScriptSourceElement sourceElement)
         {
             string code = this.WrapScript(sourceElement.Name, sourceElement.SourceCode);
 
@@ -186,7 +186,7 @@ namespace Aggregator.Core.Script
             return passed;
         }
 
-        public override bool LoadCompleted()
+        internal override bool LoadCompleted()
         {
             try
             {

--- a/Aggregator.Core/Script/DotNetScriptEngine{TCodeDomProvider}.cs
+++ b/Aggregator.Core/Script/DotNetScriptEngine{TCodeDomProvider}.cs
@@ -9,6 +9,7 @@ using System.Text.RegularExpressions;
 
 using Aggregator.Core.Interfaces;
 using Aggregator.Core.Monitoring;
+using System.Text;
 
 namespace Aggregator.Core.Script
 {
@@ -34,7 +35,7 @@ namespace Aggregator.Core.Script
         /// </summary>
         protected abstract int LinesOfCodeBeforeScript { get; }
 
-        protected abstract string WrapScript(string scriptName, string script);
+        protected abstract string WrapScript(string scriptName, string script, string functions);
 
         private string[] GetAssemblyReferences()
         {
@@ -173,20 +174,52 @@ namespace Aggregator.Core.Script
 
         private CompilerResults compilerResult;
 
-        internal override bool Load(Script.ScriptSourceElement sourceElement)
+        // a simpler pattern is , this one matches .Net identifiers
+        private readonly Regex regex = new Regex(
+            @"\${(?<name>[A-Za-z_]\w*)}",
+            //@"\${(?<name>[_\p{L}\p{Nl}][\p{L}\p{Nl}\p{Mn}\p{Mc}\p{Nd}\p{Pc}\p{Cf}]*)}",
+            RegexOptions.ExplicitCapture);
+
+        private string ReplaceMacros(string source, Dictionary<string, string> macros)
         {
-            string code = this.WrapScript(sourceElement.Name, sourceElement.SourceCode);
-
-            bool passed = this.SyntaxChecking(sourceElement.Name, code);
-            if (passed)
-            {
-                this.sourceCode.Add(sourceElement.Name, code);
-            }
-
-            return passed;
+            return this.regex.Replace(source, (Match m) => { return macros[m.Groups["name"].Value]; });
         }
 
-        internal override bool LoadCompleted()
+        public override void Load(IEnumerable<Script.ScriptSourceElement> sourceElements)
+        {
+            this.sourceCode.Clear();
+            this.GenerateSource(sourceElements);
+            this.BuildAssembly();
+        }
+
+        private void GenerateSource(IEnumerable<ScriptSourceElement> sourceElements)
+        {
+            var snippets = sourceElements.Where(e => e.Type == ScriptSourceElementType.Snippet).ToDictionary((e) => e.Name, (e) => e.SourceCode);
+
+            var functionsBuilder = new StringBuilder();
+            foreach (var funcElement in sourceElements.Where(e => e.Type == ScriptSourceElementType.Function))
+            {
+                functionsBuilder.Append(funcElement.SourceCode);
+                functionsBuilder.AppendLine();
+            }
+
+            string functionsCode = functionsBuilder.ToString();
+
+            foreach (var ruleElement in sourceElements.Where((e) => e.Type == ScriptSourceElementType.Rule))
+            {
+                string ruleCode = this.ReplaceMacros(ruleElement.SourceCode, snippets);
+
+                string code = this.WrapScript(ruleElement.Name, ruleCode, functionsCode);
+
+                bool passed = this.SyntaxChecking(ruleElement.Name, code);
+                if (passed)
+                {
+                    this.sourceCode.Add(ruleElement.Name, code);
+                }
+            }
+        }
+
+        protected bool BuildAssembly()
         {
             try
             {

--- a/Aggregator.Core/Script/DotNetScriptEngine{TCodeDomProvider}.cs
+++ b/Aggregator.Core/Script/DotNetScriptEngine{TCodeDomProvider}.cs
@@ -173,14 +173,14 @@ namespace Aggregator.Core.Script
 
         private CompilerResults compilerResult;
 
-        public override bool Load(string scriptName, string script)
+        public override bool Load(Script.ScriptSourceElement sourceElement)
         {
-            string code = this.WrapScript(scriptName, script);
+            string code = this.WrapScript(sourceElement.Name, sourceElement.SourceCode);
 
-            bool passed = this.SyntaxChecking(scriptName, code);
+            bool passed = this.SyntaxChecking(sourceElement.Name, code);
             if (passed)
             {
-                this.sourceCode.Add(scriptName, code);
+                this.sourceCode.Add(sourceElement.Name, code);
             }
 
             return passed;

--- a/Aggregator.Core/Script/PsScriptEngine.cs
+++ b/Aggregator.Core/Script/PsScriptEngine.cs
@@ -18,9 +18,12 @@ namespace Aggregator.Core
         {
         }
 
-        public override bool Load(string scriptName, string script)
+        public override bool Load(Script.ScriptSourceElement sourceElement)
         {
-            this.scripts.Add(scriptName, script);
+            if (sourceElement.Type != Script.ScriptSourceElementType.Rule)
+                return false;
+
+            this.scripts.Add(sourceElement.Name, sourceElement.SourceCode);
             return true;
         }
 

--- a/Aggregator.Core/Script/PsScriptEngine.cs
+++ b/Aggregator.Core/Script/PsScriptEngine.cs
@@ -18,7 +18,7 @@ namespace Aggregator.Core
         {
         }
 
-        public override bool Load(Script.ScriptSourceElement sourceElement)
+        internal override bool Load(Script.ScriptSourceElement sourceElement)
         {
             if (sourceElement.Type != Script.ScriptSourceElementType.Rule)
                 return false;
@@ -27,7 +27,7 @@ namespace Aggregator.Core
             return true;
         }
 
-        public override bool LoadCompleted()
+        internal override bool LoadCompleted()
         {
             return true;
         }

--- a/Aggregator.Core/Script/PsScriptEngine.cs
+++ b/Aggregator.Core/Script/PsScriptEngine.cs
@@ -1,8 +1,10 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Management.Automation.Runspaces;
 
 using Aggregator.Core.Interfaces;
 using Aggregator.Core.Monitoring;
+using Aggregator.Core.Script;
 
 namespace Aggregator.Core
 {
@@ -18,18 +20,16 @@ namespace Aggregator.Core
         {
         }
 
-        internal override bool Load(Script.ScriptSourceElement sourceElement)
+        public override void Load(IEnumerable<ScriptSourceElement> sourceElements)
         {
-            if (sourceElement.Type != Script.ScriptSourceElementType.Rule)
-                return false;
+            foreach (var sourceElement in sourceElements)
+            {
+                // TODO log something
+                if (sourceElement.Type != Script.ScriptSourceElementType.Rule)
+                    continue;
 
-            this.scripts.Add(sourceElement.Name, sourceElement.SourceCode);
-            return true;
-        }
-
-        internal override bool LoadCompleted()
-        {
-            return true;
+                this.scripts.Add(sourceElement.Name, sourceElement.SourceCode);
+            }
         }
 
         public override void Run(string scriptName, IWorkItem workItem, IWorkItemRepository store)

--- a/Aggregator.Core/Script/ScriptEngine.cs
+++ b/Aggregator.Core/Script/ScriptEngine.cs
@@ -4,7 +4,8 @@ using Aggregator.Core.Monitoring;
 namespace Aggregator.Core
 {
     using System;
-
+    using Context;
+    using System.Collections.Generic;
     /// <summary>
     /// Base class for scripting language engines.
     /// </summary>
@@ -21,13 +22,12 @@ namespace Aggregator.Core
         }
 
         /// <summary>
-        /// Register the specified <paramref name="script"/> under <paramref name="name"/>.
+        /// Register the script source code element.
         /// </summary>
-        /// <param name="scriptName">Name of the script.</param>
-        /// <param name="script">The script source code.</param>
+        /// <param name="sourceElements">The script source code element.</param>
         /// <returns>true if succeeded</returns>
         /// <remarks>An engine may pre-process/compile the script at this time to get better performances.</remarks>
-        public abstract bool Load(string scriptName, string script);
+        public abstract bool Load(Script.ScriptSourceElement sourceElement);
 
         /// <summary>
         /// Informs the engine that all script has been loaded.
@@ -49,6 +49,15 @@ namespace Aggregator.Core
             var ctor = t.GetConstructor(new Type[] { typeof(ILogEvents), typeof(bool) });
             ScriptEngine engine = ctor.Invoke(new object[] { logger, debug }) as ScriptEngine;
             return engine;
+        }
+
+        internal void Load(IEnumerable<Script.ScriptSourceElement> sourceElements)
+        {
+            foreach (var element in sourceElements)
+            {
+                this.Load(element);
+            }
+            this.LoadCompleted();
         }
 
         private static Type GetScriptEngineType(string scriptLanguage)

--- a/Aggregator.Core/Script/ScriptEngine.cs
+++ b/Aggregator.Core/Script/ScriptEngine.cs
@@ -27,13 +27,13 @@ namespace Aggregator.Core
         /// <param name="sourceElements">The script source code element.</param>
         /// <returns>true if succeeded</returns>
         /// <remarks>An engine may pre-process/compile the script at this time to get better performances.</remarks>
-        public abstract bool Load(Script.ScriptSourceElement sourceElement);
+        internal abstract bool Load(Script.ScriptSourceElement sourceElement);
 
         /// <summary>
         /// Informs the engine that all script has been loaded.
         /// </summary>
         /// <returns>true when succeeded</returns>
-        public abstract bool LoadCompleted();
+        internal abstract bool LoadCompleted();
 
         /// <summary>
         /// Runs the  script specified by <paramref name="scriptName" />.
@@ -51,7 +51,7 @@ namespace Aggregator.Core
             return engine;
         }
 
-        internal void Load(IEnumerable<Script.ScriptSourceElement> sourceElements)
+        public void Load(IEnumerable<Script.ScriptSourceElement> sourceElements)
         {
             foreach (var element in sourceElements)
             {

--- a/Aggregator.Core/Script/ScriptEngine.cs
+++ b/Aggregator.Core/Script/ScriptEngine.cs
@@ -22,20 +22,6 @@ namespace Aggregator.Core
         }
 
         /// <summary>
-        /// Register the script source code element.
-        /// </summary>
-        /// <param name="sourceElements">The script source code element.</param>
-        /// <returns>true if succeeded</returns>
-        /// <remarks>An engine may pre-process/compile the script at this time to get better performances.</remarks>
-        internal abstract bool Load(Script.ScriptSourceElement sourceElement);
-
-        /// <summary>
-        /// Informs the engine that all script has been loaded.
-        /// </summary>
-        /// <returns>true when succeeded</returns>
-        internal abstract bool LoadCompleted();
-
-        /// <summary>
         /// Runs the  script specified by <paramref name="scriptName" />.
         /// </summary>
         /// <param name="scriptName">Name of the script.</param>
@@ -51,14 +37,7 @@ namespace Aggregator.Core
             return engine;
         }
 
-        public void Load(IEnumerable<Script.ScriptSourceElement> sourceElements)
-        {
-            foreach (var element in sourceElements)
-            {
-                this.Load(element);
-            }
-            this.LoadCompleted();
-        }
+        public abstract void Load(IEnumerable<Script.ScriptSourceElement> sourceElements);
 
         private static Type GetScriptEngineType(string scriptLanguage)
         {

--- a/Aggregator.Core/Script/ScriptSourceElement.cs
+++ b/Aggregator.Core/Script/ScriptSourceElement.cs
@@ -8,13 +8,17 @@ namespace Aggregator.Core.Script
 {
     public enum ScriptSourceElementType
     {
-        Rule
+        Rule,
+        Snippet,
+        Function
     }
 
     public class ScriptSourceElement
     {
+#pragma warning disable SA1401 // FieldsMustBePrivate
         public string Name;
         public ScriptSourceElementType Type;
         public string SourceCode;
+#pragma warning restore SA1401 // FieldsMustBePrivate
     }
 }

--- a/Aggregator.Core/Script/ScriptSourceElement.cs
+++ b/Aggregator.Core/Script/ScriptSourceElement.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Aggregator.Core.Script
+{
+    public enum ScriptSourceElementType
+    {
+        Rule
+    }
+
+    public class ScriptSourceElement
+    {
+        public string Name;
+        public ScriptSourceElementType Type;
+        public string SourceCode;
+    }
+}

--- a/Aggregator.Core/Script/VBNetScriptEngine.cs
+++ b/Aggregator.Core/Script/VBNetScriptEngine.cs
@@ -21,7 +21,7 @@ namespace Aggregator.Core
             }
         }
 
-        protected override string WrapScript(string scriptName, string script)
+        protected override string WrapScript(string scriptName, string script, string functions)
         {
             return @"
 Imports Microsoft.TeamFoundation.WorkItemTracking.Client
@@ -41,6 +41,7 @@ Namespace " + this.Namespace + @"
 " + script + @"
       Return Nothing
     End Function
+" + functions + @"
   End Class
 End Namespace
 ";

--- a/UnitTests.Core/Helpers/TestHelpers.cs
+++ b/UnitTests.Core/Helpers/TestHelpers.cs
@@ -45,8 +45,7 @@ namespace UnitTests.Core
                 Name = scriptName,
                 SourceCode = script
             };
-            engine.Load(scriptElem);
-            engine.LoadCompleted();
+            engine.Load(new ScriptSourceElement[] { scriptElem });
             engine.Run(scriptName, workItem, store);
         }
     }

--- a/UnitTests.Core/Helpers/TestHelpers.cs
+++ b/UnitTests.Core/Helpers/TestHelpers.cs
@@ -40,7 +40,8 @@ namespace UnitTests.Core
 
         public static void LoadAndRun(this ScriptEngine engine, string scriptName, string script, IWorkItem workItem, IWorkItemRepository store)
         {
-            var scriptElem = new ScriptSourceElement() {
+            var scriptElem = new ScriptSourceElement()
+            {
                 Type = ScriptSourceElementType.Rule,
                 Name = scriptName,
                 SourceCode = script

--- a/UnitTests.Core/Helpers/TestHelpers.cs
+++ b/UnitTests.Core/Helpers/TestHelpers.cs
@@ -11,7 +11,7 @@ namespace UnitTests.Core
     using Aggregator.Core.Configuration;
 
     using Microsoft.VisualStudio.TestTools.UnitTesting;
-
+    using Aggregator.Core.Script;
     internal static class TestHelpers
     {
         public static string LoadTextFromEmbeddedResource(string resourceName)
@@ -40,7 +40,12 @@ namespace UnitTests.Core
 
         public static void LoadAndRun(this ScriptEngine engine, string scriptName, string script, IWorkItem workItem, IWorkItemRepository store)
         {
-            engine.Load(scriptName, script);
+            var scriptElem = new ScriptSourceElement() {
+                Type = ScriptSourceElementType.Rule,
+                Name = scriptName,
+                SourceCode = script
+            };
+            engine.Load(scriptElem);
             engine.LoadCompleted();
             engine.Run(scriptName, workItem, store);
         }

--- a/UnitTests.Core/ScriptEnginesTests.cs
+++ b/UnitTests.Core/ScriptEnginesTests.cs
@@ -294,9 +294,7 @@ loger.Log(""Test"");
             var logger = Substitute.For<ILogEvents>();
             var engine = new CSharpScriptEngine(logger, Debugger.IsAttached);
 
-            engine.Load(good_script);
-            engine.Load(bad_script);
-            engine.LoadCompleted();
+            engine.Load(new ScriptSourceElement[] { good_script, bad_script });
 
             logger.Received().ScriptHasError("bad", 2, 1, "CS0103", "The name 'loger' does not exist in the current context");
         }
@@ -321,13 +319,10 @@ logger.Log(""Test"");
 loger.Log(""Test"");
 "
             };
-
             var logger = Substitute.For<ILogEvents>();
             var engine = new VBNetScriptEngine(logger, Debugger.IsAttached);
 
-            engine.Load(good_script);
-            engine.Load(bad_script);
-            engine.LoadCompleted();
+            engine.Load(new ScriptSourceElement[] { good_script, bad_script });
 
             logger.Received().ScriptHasError("bad", 2, 0, "BC30451", "'loger' is not declared. It may be inaccessible due to its protection level.");
         }

--- a/UnitTests.Core/ScriptEnginesTests.cs
+++ b/UnitTests.Core/ScriptEnginesTests.cs
@@ -17,6 +17,7 @@ using NSubstitute;
 using UnitTests.Core.Mock;
 
 using Debugger = System.Diagnostics.Debugger;
+using Aggregator.Core.Script;
 
 namespace UnitTests.Core
 {
@@ -274,17 +275,27 @@ Return CInt(array.Average())
         [TestCategory("CSharpScript")]
         public void Catch_CSharp_rule_compile_error()
         {
-            string good_script = @"
+            var good_script = new ScriptSourceElement()
+            {
+                Name = "good",
+                Type = ScriptSourceElementType.Rule,
+                SourceCode = @"
 logger.Log(""Test"");
-";
-            string bad_script = @"
+"
+            };
+            var bad_script = new ScriptSourceElement()
+            {
+                Name = "bad",
+                Type = ScriptSourceElementType.Rule,
+                SourceCode = @"
 loger.Log(""Test"");
-";
+"
+            };
             var logger = Substitute.For<ILogEvents>();
             var engine = new CSharpScriptEngine(logger, Debugger.IsAttached);
 
-            engine.Load("good", good_script);
-            engine.Load("bad", bad_script);
+            engine.Load(good_script);
+            engine.Load(bad_script);
             engine.LoadCompleted();
 
             logger.Received().ScriptHasError("bad", 2, 1, "CS0103", "The name 'loger' does not exist in the current context");
@@ -294,17 +305,28 @@ loger.Log(""Test"");
         [TestCategory("VBNetScript")]
         public void Catch_VBNet_rule_compile_error()
         {
-            string good_script = @"
-logger.Log(""Test"")
-";
-            string bad_script = @"
-loger.Log(""Test"")
-";
+            var good_script = new ScriptSourceElement()
+            {
+                Name = "good",
+                Type = ScriptSourceElementType.Rule,
+                SourceCode = @"
+logger.Log(""Test"");
+"
+            };
+            var bad_script = new ScriptSourceElement()
+            {
+                Name = "bad",
+                Type = ScriptSourceElementType.Rule,
+                SourceCode = @"
+loger.Log(""Test"");
+"
+            };
+
             var logger = Substitute.For<ILogEvents>();
             var engine = new VBNetScriptEngine(logger, Debugger.IsAttached);
 
-            engine.Load("good", good_script);
-            engine.Load("bad", bad_script);
+            engine.Load(good_script);
+            engine.Load(bad_script);
             engine.LoadCompleted();
 
             logger.Received().ScriptHasError("bad", 2, 0, "BC30451", "'loger' is not declared. It may be inaccessible due to its protection level.");

--- a/UnitTests.Core/UnitTests.Core.csproj
+++ b/UnitTests.Core/UnitTests.Core.csproj
@@ -106,8 +106,8 @@
   </PropertyGroup>
   <Import Project="..\references\TfsReferences.target" />
   <ItemGroup>
-    <Reference Include="NSubstitute, Version=1.9.1.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
-      <HintPath>..\packages\NSubstitute.1.9.1.0\lib\net45\NSubstitute.dll</HintPath>
+    <Reference Include="NSubstitute, Version=1.10.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
+      <HintPath>..\packages\NSubstitute.1.10.0.0\lib\net45\NSubstitute.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/UnitTests.Core/packages.config
+++ b/UnitTests.Core/packages.config
@@ -12,7 +12,7 @@
   <package id="Microsoft.VisualStudio.Services.InteractiveClient" version="14.83.0" targetFramework="net45" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="1.7.0.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.5" targetFramework="net45" />
-  <package id="NSubstitute" version="1.9.1.0" targetFramework="net45" />
+  <package id="NSubstitute" version="1.10.0.0" targetFramework="net45" />
   <package id="SonarLint" version="1.6.0" targetFramework="net45" developmentDependency="true" />
   <package id="StyleCop.Analyzers" version="1.0.0-beta015" targetFramework="net45" developmentDependency="true" />
   <package id="System.IdentityModel.Tokens.Jwt" version="4.0.0" targetFramework="net45" />

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,8 +2,8 @@
 - branches:
     only:
       - master
-      - /release/*
-      - /hotfix/*
+      - /release\/.*/
+      - /hotfix\/.*/
   skip_tags: true
   configuration:
     - Debug
@@ -46,7 +46,7 @@
 - branches:
     only:
       - develop
-      - /feature/*
+      - /feature\/.*/
   skip_tags: true
   configuration:
     - Debug


### PR DESCRIPTION
As per #126 there are two new mechanisms.

- **Snippet** a macro machanism where macro invocation is replaced with test
- **Function** added to the same class generated from Rule's code

Sample:

```
<snippet name="MySnippet"><![CDATA[
    logger.Log("You entered MySnippet snippet.");
]]></snippet>

<function><![CDATA[
  int MyFunc() { return 42; }
]]></function>

<rule name="MyFirstRule" appliesTo="Task" hasFields="Title"><![CDATA[
    ${MySnippet}
    logger.Log("Hello, World from {1} #{0}!", self.Id, self.TypeName);
    logger.Log("MyFunc returns {0}.", MyFunc());
]]></rule>
```

Generated code (formatted for clarity)
```
namespace RESERVED
{
  using Microsoft.TeamFoundation.WorkItemTracking.Client;
  using Aggregator.Core;
  using Aggregator.Core.Extensions;
  using Aggregator.Core.Interfaces;
  using Aggregator.Core.Navigation;
  using Aggregator.Core.Monitoring;
  using System.Linq;
  using CoreFieldReferenceNames = Microsoft.TeamFoundation.WorkItemTracking.Client.CoreFieldReferenceNames;

  public class Script_rule1 : Aggregator.Core.Script.IDotNetScript
  {
    public object RunScript(Aggregator.Core.Interfaces.IWorkItemExposed self, Aggregator.Core.Interfaces.IWorkItemRepositoryExposed store, Aggregator.Core.Monitoring.IRuleLogger logger)
    {
      logger.Log("This is MySnippet code.");
      logger.Log("Hello, World from {1} #{0}!", self.Id, self.TypeName);
      logger.Log("MyFunc returns {0}.", MyFunc());
      return null;
    }

    int MyFunc()
    {
      return 42;
    }
  }
}
```
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tfsaggregator/tfsaggregator/128)
<!-- Reviewable:end -->
