### PR TITLE
Fix issue #160

### DIFF
--- a/UnitTests.Core/GlobalListsTests.cs
+++ b/UnitTests.Core/GlobalListsTests.cs
@@ -41,7 +41,7 @@ namespace UnitTests.Core
                 new System.Uri("http://localhost:8080/tfs/DefaultCollection"));
 
             var repository = new WorkItemRepositoryMock();
-            var runtime = RuntimeContext.MakeRuntimeContext("settingsPath", settings, context, logger, (c, i, l) => repository);
+            var runtime = RuntimeContext.MakeRuntimeContext(@"C:\GlobalList_UserParameterAddValue_Succeeded", settings, context, logger, (c, i, l) => repository);
 
             var workItem = new WorkItemMock(repository, runtime);
             workItem.Id = 1;
@@ -75,7 +75,7 @@ namespace UnitTests.Core
             var context = Substitute.For<IRequestContext>();
             context.GetProjectCollectionUri().Returns(
                 new System.Uri("http://localhost:8080/tfs/DefaultCollection"));
-            var runtime = RuntimeContext.MakeRuntimeContext("settingsPath", settings, context, logger, (c, i, l) => repository);
+            var runtime = RuntimeContext.MakeRuntimeContext(@"C:\GlobalList_UserParameterReplaceExisting_Succeeded", settings, context, logger, (c, i, l) => repository);
 
             var workItem = new WorkItemMock(repository, runtime);
             workItem.Id = 1;

--- a/UnitTests.Core/ItemCreationTests.cs
+++ b/UnitTests.Core/ItemCreationTests.cs
@@ -29,7 +29,7 @@ namespace UnitTests.Core
             var context = Substitute.For<IRequestContext>();
             context.GetProjectCollectionUri().Returns(
                 new System.Uri("http://localhost:8080/tfs/DefaultCollection"));
-            var runtime = RuntimeContext.MakeRuntimeContext("settingsPath", settings, context, logger, (c, i, l) => repository);
+            var runtime = RuntimeContext.MakeRuntimeContext(@"C:\WorkItemLink_addNew_succeeds", settings, context, logger, (c, i, l) => repository);
 
             var parent = new WorkItemMock(repository, runtime);
             parent.Id = 1;
@@ -67,7 +67,7 @@ namespace UnitTests.Core
             var context = Substitute.For<IRequestContext>();
             context.GetProjectCollectionUri().Returns(
                 new System.Uri("http://localhost:8080/tfs/DefaultCollection"));
-            var runtime = RuntimeContext.MakeRuntimeContext("settingsPath", settings, context, logger, (c, i, l) => repository);
+            var runtime = RuntimeContext.MakeRuntimeContext(@"C:\WorkItemLink_addExisting_noop", settings, context, logger, (c, i, l) => repository);
 
             var parent = new WorkItemMock(repository, runtime);
             parent.Id = 1;
@@ -107,7 +107,7 @@ namespace UnitTests.Core
             var context = Substitute.For<IRequestContext>();
             context.GetProjectCollectionUri().Returns(
                 new System.Uri("http://localhost:8080/tfs/DefaultCollection"));
-            var runtime = RuntimeContext.MakeRuntimeContext("settingsPath", settings, context, logger, (c, i, l) => repository);
+            var runtime = RuntimeContext.MakeRuntimeContext(@"C:\WorkItem_addNew_succeeds", settings, context, logger, (c, i, l) => repository);
 
             var parent = new WorkItemMock(repository, runtime);
             parent.Id = 1;

--- a/UnitTests.Core/RulesAndPolicyTests.cs
+++ b/UnitTests.Core/RulesAndPolicyTests.cs
@@ -51,7 +51,7 @@ namespace UnitTests.Core
             context.GetProjectCollectionUri().Returns(
                 new System.Uri("http://localhost:8080/tfs/DefaultCollection"));
             context.CollectionName.Returns("Collection1");
-            var runtime = RuntimeContext.MakeRuntimeContext("settingsPath", settings, context, logger, (c, i, l) => repository);
+            var runtime = RuntimeContext.MakeRuntimeContext(@"C:\RulesAndPolicy_SpecificCollection_TwoPoliciesTwoRulesApplies", settings, context, logger, (c, i, l) => repository);
 
             using (var processor = new EventProcessor(runtime))
             {
@@ -81,7 +81,7 @@ namespace UnitTests.Core
             context.GetProjectCollectionUri().Returns(
                 new System.Uri("http://localhost:8080/tfs/DefaultCollection"));
             context.CollectionName.Returns("Collection2");
-            var runtime = RuntimeContext.MakeRuntimeContext("settingsPath", settings, context, logger, (c, i, l) => repository);
+            var runtime = RuntimeContext.MakeRuntimeContext(@"C:\RulesAndPolicy_GenericCollection_OnePoliciesOneRulesApplies", settings, context, logger, (c, i, l) => repository);
             using (var processor = new EventProcessor(runtime))
             {
                 var notification = Substitute.For<INotification>();
@@ -110,7 +110,7 @@ namespace UnitTests.Core
             context.GetProjectCollectionUri().Returns(
                 new System.Uri("http://localhost:8080/tfs/DefaultCollection"));
             context.CollectionName.Returns("Collection2");
-            var runtime = RuntimeContext.MakeRuntimeContext("settingsPath", settings, context, logger, (c, i, l) => repository);
+            var runtime = RuntimeContext.MakeRuntimeContext(@"C:\RulesAndPolicy_TypeFilter_OnePoliciesOneRulesApplies", settings, context, logger, (c, i, l) => repository);
 
             var workItem = new WorkItemMock(repository, runtime);
             workItem.Id = 1;

--- a/UnitTests.Core/ScriptEnginesTests.cs
+++ b/UnitTests.Core/ScriptEnginesTests.cs
@@ -185,7 +185,7 @@ return $self.Fields[""z""].Value ";
             var context = Substitute.For<IRequestContext>();
             context.GetProjectCollectionUri().Returns(
                 new System.Uri("http://localhost:8080/tfs/DefaultCollection"));
-            var runtime = RuntimeContext.MakeRuntimeContext("settingsPath", settings, context, logger, (c, i, l) => repository);
+            var runtime = RuntimeContext.MakeRuntimeContext(@"C:\Can_execute_a_Powershell_noop_rule", settings, context, logger, (c, i, l) => repository);
             using (var processor = new EventProcessor(runtime))
             {
                 var notification = Substitute.For<INotification>();

--- a/UnitTests.Core/SingleParentChildAggregationsTests.cs
+++ b/UnitTests.Core/SingleParentChildAggregationsTests.cs
@@ -75,7 +75,7 @@ namespace UnitTests.Core
             var context = Substitute.For<IRequestContext>();
             context.GetProjectCollectionUri().Returns(
                 new System.Uri("http://localhost:8080/tfs/DefaultCollection"));
-            var runtime = RuntimeContext.MakeRuntimeContext("settingsPath", settings, context, logger, (c, i, l) => alternateRepository);
+            var runtime = RuntimeContext.MakeRuntimeContext(@"C:\Should_aggregate_a_numeric_field", settings, context, logger, (c, i, l) => alternateRepository);
             using (var processor = new EventProcessor(runtime))
             {
                 var notification = Substitute.For<INotification>();
@@ -99,7 +99,7 @@ namespace UnitTests.Core
             var context = Substitute.For<IRequestContext>();
             context.GetProjectCollectionUri().Returns(
                 new System.Uri("http://localhost:8080/tfs/DefaultCollection"));
-            var runtime = RuntimeContext.MakeRuntimeContext("settingsPath", settings, context, logger, (c, i, l) => alternateRepository);
+            var runtime = RuntimeContext.MakeRuntimeContext(@"C:\Should_aggregate_a_numeric_field_short", settings, context, logger, (c, i, l) => alternateRepository);
             using (var processor = new EventProcessor(runtime))
             {
                 var notification = Substitute.For<INotification>();
@@ -123,7 +123,7 @@ namespace UnitTests.Core
             var context = Substitute.For<IRequestContext>();
             context.GetProjectCollectionUri().Returns(
                 new System.Uri("http://localhost:8080/tfs/DefaultCollection"));
-            var runtime = RuntimeContext.MakeRuntimeContext("settingsPath", settings, context, logger, (c, i, l) => alternateRepository);
+            var runtime = RuntimeContext.MakeRuntimeContext(@"C:\Should_aggregate_a_numeric_field_VB", settings, context, logger, (c, i, l) => alternateRepository);
             using (var processor = new EventProcessor(runtime))
             {
                 var notification = Substitute.For<INotification>();
@@ -149,7 +149,7 @@ namespace UnitTests.Core
             context.GetProjectCollectionUri().Returns(
                 new System.Uri("http://localhost:8080/tfs/DefaultCollection"));
             context.CollectionName.Returns("Collection1");
-            var runtime = RuntimeContext.MakeRuntimeContext("settingsPath", settings, context, logger, (c, i, r) => alternateRepository);
+            var runtime = RuntimeContext.MakeRuntimeContext(@"C:\Should_aggregate_to_parent", settings, context, logger, (c, i, r) => alternateRepository);
 
             var grandParent = new WorkItemMock(alternateRepository, runtime);
             grandParent.Id = 1;
@@ -207,7 +207,7 @@ namespace UnitTests.Core
             var context = Substitute.For<IRequestContext>();
             context.GetProjectCollectionUri().Returns(
                 new System.Uri("http://localhost:8080/tfs/DefaultCollection"));
-            var runtime = RuntimeContext.MakeRuntimeContext("settingsPath", settings, context, logger, (c, i, l) => alternateRepository);
+            var runtime = RuntimeContext.MakeRuntimeContext(@"C:\Should_aggregate_to_parent_should_handle_null", settings, context, logger, (c, i, l) => alternateRepository);
 
             var grandParent = new WorkItemMock(alternateRepository, runtime);
             grandParent.Id = 1;


### PR DESCRIPTION
Each request gets a new `RuntimeContext` clone, but the `ScriptEngine` object will be created at later time and stored in the clone... which is discarded at the end of the request. Net result: no caching of the scripting engine.

Fixed by storing the computed engine in the cache. It cannot be built at the same time as the context because we do not have the WorkitemRepo, which is built later.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tfsaggregator/tfsaggregator/161)
<!-- Reviewable:end -->
