### PR TITLE
Add the trim onto each configuration parameter split

### DIFF
--- a/Aggregator.Core/Aggregator.Core/Configuration/AggregatorSettingsXmlParser.cs
+++ b/Aggregator.Core/Aggregator.Core/Configuration/AggregatorSettingsXmlParser.cs
@@ -205,7 +205,7 @@ namespace Aggregator.Core.Configuration
                             case "collectionScope":
                                 {
                                     var collections = new List<string>();
-                                    collections.AddRange((element.Attribute("collections") ?? nullAttribute).Value.Split(ListSeparators));
+                                    collections.AddRange((element.Attribute("collections") ?? nullAttribute).Value.Split(ListSeparators).Select(c => c.Trim()));
                                     scope.Add(new CollectionScope() { CollectionNames = collections });
                                     break;
                                 }
@@ -233,7 +233,7 @@ namespace Aggregator.Core.Configuration
                             case "projectScope":
                                 {
                                     var projects = new List<string>();
-                                    projects.AddRange((element.Attribute("projects") ?? nullAttribute).Value.Split(ListSeparators));
+                                    projects.AddRange((element.Attribute("projects") ?? nullAttribute).Value.Split(ListSeparators).Select(p => p.Trim()));
                                     scope.Add(new ProjectScope() { ProjectNames = projects });
                                     break;
                                 }
@@ -310,17 +310,17 @@ namespace Aggregator.Core.Configuration
 
                     if (ruleElem.Attribute("appliesTo") != null)
                     {
-                        ruleScopes.Add(new WorkItemTypeScope() { ApplicableTypes = ruleElem.Attribute("appliesTo").Value.Split(ListSeparators) });
+                        ruleScopes.Add(new WorkItemTypeScope() { ApplicableTypes = ruleElem.Attribute("appliesTo").Value.Split(ListSeparators).Select(r => r.Trim()) });
                     }
 
                     if (ruleElem.Attribute("hasFields") != null)
                     {
-                        ruleScopes.Add(new HasFieldsScope() { FieldNames = ruleElem.Attribute("hasFields").Value.Split(ListSeparators) });
+                        ruleScopes.Add(new HasFieldsScope() { FieldNames = ruleElem.Attribute("hasFields").Value.Split(ListSeparators).Select(r => r.Trim()) });
                     }
 
                     if (ruleElem.Attribute("changes") != null)
                     {
-                        ruleScopes.Add(new ChangeTypeScope() { ApplicableChanges = ruleElem.Attribute("changes").Value.Split(ListSeparators) });
+                        ruleScopes.Add(new ChangeTypeScope() { ApplicableChanges = ruleElem.Attribute("changes").Value.Split(ListSeparators).Select(r => r.Trim()) });
                     }
 
                     rule.Scope = ruleScopes.ToArray();


### PR DESCRIPTION
## Issue this PR addresses
Currently if you have the following rule

`<rule name="NewRuleTask" appliesTo="Product Backlog Item; Bug">`

Then the WIT Product Backlog Item will be matched but the WIT Bug will not. This is because the underlying split() will include the leading space in the second bug WIT.

The valid XML is with no leading spaces

`<rule name="NewRuleTask" appliesTo="Product Backlog Item;Bug">`


This issue is not noted in the documentation (or at least I could not see it) and took me a long time to spot as in the logger the leading space is impossible to see.

Fixes #382

## Fix in this PR
All of the configuration split() calls now do a trim on the resultant array items, thus avoiding this issues

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tfsaggregator/tfsaggregator/381)
<!-- Reviewable:end -->
