### PR TITLE
Trim any configuration value strings before comparison 

### DIFF
--- a/Aggregator.Core/Aggregator.Core/Extensions/StringExtensions.cs
+++ b/Aggregator.Core/Aggregator.Core/Extensions/StringExtensions.cs
@@ -12,7 +12,7 @@ namespace Aggregator.Core.Extensions
         /// <returns></returns>
         public static bool SameAs(this string lhs, string rhs)
         {
-            return lhs == "*" || rhs == "*" || string.Equals(lhs, rhs, StringComparison.OrdinalIgnoreCase);
+            return lhs.Trim() == "*" || rhs.Trim() == "*" || string.Equals(lhs.Trim(), rhs.Trim(), StringComparison.OrdinalIgnoreCase);
         }
 
         public static string Truncate(this string value, int maxLength)


### PR DESCRIPTION
A second attempt to that fixes #382 without the backwards compatibility issues of #381 

Actually, a simpler fix, to make sure the comparator always does a trim. This should work for all versions of .NET framework

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tfsaggregator/tfsaggregator/384)
<!-- Reviewable:end -->
