### PR TITLE
Updated product.wxs to add properties for Azure DevOps 2022.1 RTW

### DIFF
--- a/Setup.Aggregator/Product.wxs
+++ b/Setup.Aggregator/Product.wxs
@@ -355,7 +355,8 @@
     </SetProperty>
     <SetProperty Id="TEAMFOUNDATIONSERVERVERSION" Value="2022.1" Before="LaunchConditions" Action="TFSVer2022u1">
       <!-- 19.225.34108.1 (Azure DevOps Server 2022 Update 1 RC1) -->
-      <![CDATA[TEAMFOUNDATIONSERVER2022 AND (TEAMFOUNDATIONSERVER2022BUILD = "19.225.34108.1")]]>
+      <!-- 19.225.34309.2 (Azure DevOps Server 2022 Update 1 RTW) -->
+      <![CDATA[TEAMFOUNDATIONSERVER2022 AND (TEAMFOUNDATIONSERVER2022BUILD = "19.225.34108.1" OR TEAMFOUNDATIONSERVER2022BUILD = "19.225.34309.2")]]>
     </SetProperty>
 
     <Directory Id="TARGETDIR" Name="SourceDir">


### PR DESCRIPTION
Updated installer to recognize Azure DevOps 2022.1 RTW as discussed in #397

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tfsaggregator/tfsaggregator/398)
<!-- Reviewable:end -->
